### PR TITLE
Update file-create to force mode 600

### DIFF
--- a/b2
+++ b/b2
@@ -253,7 +253,8 @@ class StoredAccountInfo(object):
         return names_to_ids.get(bucket_name)
 
     def _write_file(self):
-        with open(self.filename, 'wb') as f:
+#       with open(self.filename, 'wb') as f:
+        with os.fdopen(os.open(self.filename, os.O_WRONLY | os.O_CREAT, 0600), 'wb') as f:
             f.write(json.dumps(self.data, indent=4, sort_keys=True))
             f.write('\n')
 


### PR DESCRIPTION
Currently, the b2 tool, when creating a new `${HOME}/.b2_account_info` file uses the interactive shell's `umask` setting to set the permissions on the file. This update forces the file to be created as mode 600 - which would be the better setting on a shared-access system.
