### PR TITLE
Fix write mode

### DIFF
--- a/b2
+++ b/b2
@@ -254,7 +254,7 @@ class StoredAccountInfo(object):
 
     def _write_file(self):
 #       with open(self.filename, 'wb') as f:
-        with os.fdopen(os.open(self.filename, os.O_WRONLY | os.O_CREAT, 0600), 'wb') as f:
+        with os.fdopen(os.open(self.filename, os.O_WRONLY | os.O_CREAT, 0600), 'w') as f:
             f.write(json.dumps(self.data, indent=4, sort_keys=True))
             f.write('\n')
 


### PR DESCRIPTION
Fixes regression from PR #6. Using truncating, rather than appending, open operation.

This update will not correct the permission on `${HOME}/.b2_account_info` if it already exists and is already incorrectly set.
