### PR TITLE
Support external SHA1 sum

### DIFF
--- a/b2
+++ b/b2
@@ -117,7 +117,7 @@ Usages:
         Updates the bucketType of an existing bucket.  Prints the ID
         of the bucket updated.
 
-    b2 upload_file [--contentType <contentType>] [--info <key>=<value>]* <bucketName> <localFilePath> <b2FileName>
+    b2 upload_file [--sha1 <sha1sum>] [--contentType <contentType>] [--info <key>=<value>]* <bucketName> <localFilePath> <b2FileName>
 
         Uploads one file to the given bucket.  Uploads the contents
         of the local file, and assigns the given name to the B2 file.
@@ -685,9 +685,14 @@ def upload_file(args):
 
     content_type = 'b2/x-auto'
     file_infos = {}
+    sha1sum = ''
+
     while 0 < len(args) and args[0][0] == '-':
         option = args[0]
-        if option == '--contentType':
+        if option == '--sha1':
+            sha1sum = args[1]
+            args = args[2:]
+        elif option == '--contentType':
             if len(args) < 2:
                 usage_and_exit()
             content_type = args[1]
@@ -719,7 +724,7 @@ def upload_file(args):
             'Authorization': bucket_upload_data[StoredAccountInfo.BUCKET_UPLOAD_AUTH_TOKEN],
             'X-Bz-File-Name': b2_url_encode(b2_file),
             'Content-Type': content_type,
-            'X-Bz-Content-Sha1': hex_sha1_of_file(local_file)
+            'X-Bz-Content-Sha1': sha1sum or hex_sha1_of_file(local_file)
             }
         for (k, v) in file_infos.iteritems():
             headers['X-Bz-Info-' + k] = b2_url_encode(v)


### PR DESCRIPTION
My use case includes uploading large files to B2 (100-200 GB) and I would prefer not to have to read the whole file purely to get the SHA1 checksum when I already have those sums locally during file creation.

