### PR TITLE
Added new 'sync' action for easy local <-> remote copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# B2_Command_Line_Tool
+# B2 Command Line Tool
+
 The command-line tool that gives easy access to all of the capabilities of B2 Cloud Storage.
 
 This program provides command-line access to the B2 service.
@@ -86,6 +87,17 @@ Usages:
 
         Prints an URL that can be used to download the given file, if
         it is public.
+
+    b2 sync [--delete] [--hide] <source> <destination>
+
+        Uploads or downloads multiple files from source to destination.
+        One of the paths must be a local file path, and the other must be
+        a B2 bucket path. Use "b2:<bucketName>/<prefix>" for B2 paths, e.g.
+        "b2:my-bucket-name/a/path/prefix/".
+
+        If the --delete or --hide flags are specified, destination files
+        are deleted or hidden if not present in the source path. Note that
+        files are matched only by name and size.
 
     b2 update_bucket <bucketName> <bucketType>
 

--- a/b2
+++ b/b2
@@ -1110,7 +1110,7 @@ def sync(args):
         if is_b2_src and remote_file and not is_match:
             if not os.path.exists(dirpath):
                 os.makedirs(dirpath)
-            download_file_by_id([remote_file['fileId'], file_local_path])
+            download_file_by_id([remote_file['fileId'], filepath])
         elif is_b2_src and not remote_file and options['delete']:
             os.remove(filepath)
         elif not is_b2_src and local_file and not is_match:

--- a/b2
+++ b/b2
@@ -1029,6 +1029,30 @@ def ls(args):
                 prefix + current_dir[:-1] + '0'
                 )
 
+def iter_files(info, bucket_name, api='b2_list_file_names', start_name=None, count=1000):
+    info = StoredAccountInfo()
+    auth_token = info.get_account_auth_token()
+    url = url_for_api(info, api)
+    params = {
+        'bucketId': get_bucket_id_from_bucket_name(info, bucket_name),
+        'startFileName': start_name,
+        'maxFileCount': count
+    }
+    loop = True
+    while loop:
+        response = post_json(url, params, auth_token)
+        for file in response.get('files', []):
+            name = file['fileName']
+            if not start_name or name.startswith(start_name):
+                yield file
+            else:
+                loop = False
+        if response.get('nextFileId'):
+            params['startFileId'] = response['nextFileId']
+        elif response.get('nextFileName'):
+            params['startFileName'] = response['nextFileName']
+        else:
+            loop = False
 
 def sync(args):
     options = {'delete': False, 'hide': False}
@@ -1060,31 +1084,14 @@ def sync(args):
     # Find all matching files in B2
     remote_files = {}
     info = StoredAccountInfo()
-    bucket_id = get_bucket_id_from_bucket_name(info, bucket_name)
-    auth_token = info.get_account_auth_token()
-    start_file_name = bucket_prefix or None
-    while True:
-        url = url_for_api(info, 'b2_list_file_names')
-        params = {
-            'bucketId' : bucket_id
+    for file in iter_files(info, bucket_name, start_name=bucket_prefix or None):
+        name = file['fileName']
+        after_prefix = name[len(bucket_prefix):]
+        remote_files[after_prefix] = {
+            'fileName': after_prefix,
+            'fileId': file['fileId'],
+            'size': file['size']
         }
-        if start_file_name:
-            params['startFileName'] = start_file_name
-        response = post_json(url, params, auth_token)
-        for file in response['files']:
-            name = file['fileName']
-            if not name.startswith(bucket_prefix):
-                response['nextFileName'] = None
-                break
-            after_prefix = name[len(bucket_prefix):]
-            remote_files[after_prefix] = {
-                'fileName': after_prefix,
-                'fileId': file['fileId'],
-                'size': file['size']
-            }
-        if response['nextFileName'] is None:
-            break
-        start_file_name = response['nextFileName']
 
     # Find all matching local files
     local_files = {}

--- a/b2
+++ b/b2
@@ -860,6 +860,9 @@ def download_file_from_url(url, request_body, encoded_headers, local_file_name, 
                 f.write(data)
                 digest.update(data)
                 bytes_read += len(data)
+        if info.get('x-bz-info-src_last_modified_millis'):
+            mtime = int(info['x-bz-info-src_last_modified_millis']) / 1000
+            os.utime(local_file_name, (mtime, mtime))
         if bytes_read != int(info['content-length']):
             print 'ERROR: only %d of %d bytes read' % (bytes_read, file_size)
         if digest.hexdigest() != file_sha1:

--- a/b2
+++ b/b2
@@ -833,24 +833,25 @@ def upload_file(args):
     sys.exit(1)
 
 
-def download_file_from_url(url, request_body, encoded_headers, local_file_name, progress_bar=False):
+def download_file_from_url(url, request_body, encoded_headers, local_file_name, print_progress=False):
     with OpenUrl(url, request_body, encoded_headers) as response:
         info = response.info()
         file_size = int(info['content-length'])
         file_sha1 = info['x-bz-content-sha1']
-        print 'File name:   ', info['x-bz-file-name']
-        print 'File size:   ', file_size
-        print 'Content type:', info['content-type']
-        print 'Content sha1:', file_sha1
+        if print_progress:
+            print 'File name:   ', info['x-bz-file-name']
+            print 'File size:   ', file_size
+            print 'Content type:', info['content-type']
+            print 'Content sha1:', file_sha1
         for name in info:
-            if name.startswith('x-bz-info-'):
+            if name.startswith('x-bz-info-') and print_progress:
                 print 'INFO', name[10:] + ':', info[name]
         block_size = 4096
         digest = hashlib.sha1()
         bytes_read = 0
 
         stream = open(local_file_name, 'wb')
-        if PROGRESS_BAR_SUPPORT and progress_bar:
+        if PROGRESS_BAR_SUPPORT and print_progress:
             stream = StreamWithProgress(stream, desc=local_file_name, total=file_size)
         with stream as f:
             while True:
@@ -867,7 +868,8 @@ def download_file_from_url(url, request_body, encoded_headers, local_file_name, 
             print 'ERROR: only %d of %d bytes read' % (bytes_read, file_size)
         if digest.hexdigest() != file_sha1:
             print 'ERROR: sha1 checksum mismatch -- bad data'
-        print 'checksum matches'
+        if print_progress:
+            print 'checksum matches'
 
 
 def download_file_by_id(args):
@@ -886,7 +888,7 @@ def download_file_by_id(args):
 
     request_body = json.dumps(params)
 
-    download_file_from_url(url, request_body, headers, local_file_name, progress_bar=True)
+    download_file_from_url(url, request_body, headers, local_file_name, print_progress=True)
 
 
 def download_file_by_name(args):
@@ -903,7 +905,7 @@ def download_file_by_name(args):
     url = info.get_download_url() + '/file/' + b2_url_encode(bucket_name) + '/' + b2_url_encode(file_name)
     headers = { 'Authorization' : auth_token }
 
-    download_file_from_url(url, None, headers, local_file_name, progress_bar=True)
+    download_file_from_url(url, None, headers, local_file_name, print_progress=True)
 
 
 def make_url(args):
@@ -1085,8 +1087,8 @@ def sync(args):
         bucket_prefix += '/'
 
     # Find all matching files in B2
-    remote_files = {}
     info = StoredAccountInfo()
+    remote_files = {}
     for file in iter_files(info, bucket_name, start_name=bucket_prefix or None):
         name = file['fileName']
         after_prefix = name[len(bucket_prefix):]
@@ -1118,17 +1120,44 @@ def sync(args):
         remote_file = remote_files.get(filename)
         is_match = local_file and remote_file and local_file['size'] == remote_file['size']
         if is_b2_src and remote_file and not is_match:
+            print "+ %s" % filename
             if not os.path.exists(dirpath):
                 os.makedirs(dirpath)
-            download_file_by_id([remote_file['fileId'], filepath])
+            url = url_for_api(info, 'b2_download_file_by_id')
+            headers = { 'Authorization': info.get_account_auth_token() }
+            params = { 'fileId': remote_file['fileId'] }
+            download_file_from_url(url, json.dumps(params), headers, filepath)
         elif is_b2_src and not remote_file and options['delete']:
+            print "- %s" % filename
             os.remove(filepath)
         elif not is_b2_src and local_file and not is_match:
-            upload_file([bucket_name, filepath, b2_path])
+            print "+ %s" % filename
+            url = url_for_api(info, 'b2_get_upload_url')
+            params = { 'bucketId': get_bucket_id_from_bucket_name(info, bucket_name) }
+            response = post_json(url, params, info.get_account_auth_token())
+            upload_url = response['uploadUrl']
+            upload_auth_token = response['authorizationToken']
+            headers = {
+                'Authorization': upload_auth_token,
+                'Content-Type': 'b2/x-auto',
+                'X-Bz-File-Name': b2_url_encode(b2_path),
+                'X-Bz-Content-Sha1': hex_sha1_of_file(filepath),
+                'X-Bz-Info-src_last_modified_millis': int(os.path.getmtime(filepath) * 1000)
+            }
+            post_file(upload_url, headers, filepath)
         elif not is_b2_src and not local_file and options['delete']:
-            delete_file_version([b2_path, remote_file['fileId']])
+            print "- %s" % filename
+            url = url_for_api(info, 'b2_delete_file_version')
+            params = { 'fileName': b2_path, 'fileId': remote_file['fileId'] }
+            post_json(url, params, info.get_account_auth_token())
         elif not is_b2_src and not local_file and options['hide']:
-            hide_file([bucket_name, b2_path])
+            print ". %s" % filename
+            url = url_for_api(info, 'b2_hide_file')
+            params = {
+                'bucketId': get_bucket_id_from_bucket_name(info, bucket_name),
+                'fileName': b2_path
+            }
+            post_json(url, params, info.get_account_auth_token())
 
     # Remove empty local directories
     if is_b2_src and options['delete']:

--- a/b2
+++ b/b2
@@ -125,6 +125,17 @@ Usages:
         Prints an URL that can be used to download the given file, if
         it is public.
 
+    b2 sync [--delete] [--hide] <source> <destination>
+
+        Uploads or downloads multiple files from source to destination.
+        One of the paths must be a local file path, and the other must be
+        a B2 bucket path. Use "b2:<bucketName>/<prefix>" for B2 paths, e.g.
+        "b2:my-bucket-name/a/path/prefix/".
+
+        If the --delete or --hide flags are specified, destination files
+        are deleted or hidden if not present in the source path. Note that
+        files are matched only by name and size.
+
     b2 update_bucket <bucketName> <bucketType>
 
         Updates the bucketType of an existing bucket.  Prints the ID
@@ -1019,6 +1030,106 @@ def ls(args):
                 )
 
 
+def sync(args):
+    options = {'delete': False, 'hide': False}
+    while args and args[0][0] == '-':
+        option = args[0]
+        args = args[1:]
+        if option == '--delete':
+            options['delete'] = True
+        elif option == '--hide':
+            options['hide'] = True
+        else:
+            message_and_exit('ERROR: unknown option: ' + option)
+    if len(args) != 2:
+        usage_and_exit()
+    src = args[0]
+    dst = args[1]
+    local_path = src if dst.startswith('b2:') else dst
+    b2_path = dst if dst.startswith('b2:') else src
+    is_b2_src = b2_path == src
+    if local_path.startswith('b2:') or not b2_path.startswith('b2:'):
+        message_and_exit('ERROR: one of the paths must be a "b2:<bucket>" URI')
+    elif not os.path.exists(local_path):
+        message_and_exit('ERROR: local path doesn\'t exist: ' + local_path)
+    bucket_name = b2_path[3:].split('/')[0]
+    bucket_prefix = '/'.join(b2_path[3:].split('/')[1:])
+    if bucket_prefix and not bucket_prefix.endswith('/'):
+        bucket_prefix += '/'
+
+    # Find all matching files in B2
+    remote_files = {}
+    info = StoredAccountInfo()
+    bucket_id = get_bucket_id_from_bucket_name(info, bucket_name)
+    auth_token = info.get_account_auth_token()
+    start_file_name = bucket_prefix or None
+    while True:
+        url = url_for_api(info, 'b2_list_file_names')
+        params = {
+            'bucketId' : bucket_id
+        }
+        if start_file_name:
+            params['startFileName'] = start_file_name
+        response = post_json(url, params, auth_token)
+        for file in response['files']:
+            name = file['fileName']
+            if not name.startswith(bucket_prefix):
+                response['nextFileName'] = None
+                break
+            after_prefix = name[len(bucket_prefix):]
+            remote_files[after_prefix] = {
+                'fileName': after_prefix,
+                'fileId': file['fileId'],
+                'size': file['size']
+            }
+        if response['nextFileName'] is None:
+            break
+        start_file_name = response['nextFileName']
+
+    # Find all matching local files
+    local_files = {}
+    for dirpath, dirnames, filenames in os.walk(local_path):
+        for filename in filenames:
+            abspath = os.path.join(dirpath, filename)
+            relpath = os.path.relpath(abspath, local_path)
+            local_files[relpath] = {
+                'fileName': relpath,
+                'size': os.path.getsize(abspath)
+            }
+
+    # Process differences
+    local_fileset = set(local_files.keys())
+    remote_fileset = set(remote_files.keys())
+    for filename in local_fileset | remote_fileset:
+        filepath = os.path.join(local_path, filename)
+        dirpath = os.path.dirname(filepath)
+        b2_path = os.path.join(bucket_prefix, filename)
+        local_file = local_files.get(filename)
+        remote_file = remote_files.get(filename)
+        is_match = local_file and remote_file and local_file['size'] == remote_file['size']
+        if is_b2_src and remote_file and not is_match:
+            if not os.path.exists(dirpath):
+                os.makedirs(dirpath)
+            download_file_by_id([remote_file['fileId'], file_local_path])
+        elif is_b2_src and not remote_file and options['delete']:
+            os.remove(filepath)
+        elif not is_b2_src and local_file and not is_match:
+            upload_file([bucket_name, filepath, b2_path])
+        elif not is_b2_src and not local_file and options['delete']:
+            delete_file_version([b2_path, remote_file['fileId']])
+        elif not is_b2_src and not local_file and options['hide']:
+            hide_file([bucket_name, b2_path])
+
+    # Remove empty local directories
+    if is_b2_src and options['delete']:
+        for dirpath, dirnames, filenames in os.walk(local_path, topdown=False):
+            for name in dirnames:
+                try:
+                    os.rmdir(os.path.join(dirpath, name))
+                except:
+                    pass
+
+
 def main():
     if len(sys.argv) < 2:
         usage_and_exit()
@@ -1056,6 +1167,8 @@ def main():
         ls(args)
     elif action == 'make_url':
         make_url(args)
+    elif action == 'sync':
+        sync(args)
     elif action == 'update_bucket':
         update_bucket(args)
     elif action == 'upload_file':


### PR DESCRIPTION
Not the very cleanest of implementations. A few rough corners:

* Compares on file name and size only.
* ~~Doesn't preserve last modified timestamps.~~ *FIXED*
* ~~Re-uses other actions as helpers, which is non-optimal...~~ *FIXED*
* ~~Output is not understandable (each action outputs differently)~~ *FIXED*
* The `--delete` option doesn't work if multiple B2 file versions exists.
* Symlinks and other special files are handled as ordinary files.

The comparison should reuse the SHA-1 calculated during the upload, but it doesn't seem to be available via the API.

~~Most other issues above seem easy enough to address with a few refactorings here and there. But I won't embark on that unless this PR seems interesting to you.~~