### PR TITLE
Allow credential file name to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Usages:
         The application key is a 40-digit hex number that you can get from
         your account page on backblaze.com.
 
-        Stores an account auth token in ~/.b2_account_info
+        Stores an account auth token in ~/.b2_account_info.  This can be overridden using the
+        B2_ACCOUNT_INFO environment variable.
 
     b2 clear_account
 

--- a/b2
+++ b/b2
@@ -25,7 +25,7 @@ import getpass
 import hashlib
 import httplib
 import json
-import os.path
+import os.path, os.environ
 import socket
 import stat
 import sys

--- a/b2
+++ b/b2
@@ -1113,9 +1113,8 @@ class StoredAccountInfo(AbstractAccountInfo):
     DOWNLOAD_URL = 'download_url'
 
     def __init__(self):
-        account_info_filename = os.environ['B2_ACCOUNT_INFO']
-        if account_info_filename is None : account_info_filename = '~/.b2_account_info'
-        self.filename = os.path.expanduser(account_info_filename)
+        user_account_info_path = os.environ.get('B2_ACCOUNT_INFO', '~/.b2_account_info')
+        self.filename = os.path.expanduser(user_account_info_path)
         self.data = self._try_to_read_file()
         if self.BUCKET_UPLOAD_DATA not in self.data:
             self.data[self.BUCKET_UPLOAD_DATA] = {}

--- a/b2
+++ b/b2
@@ -59,7 +59,8 @@ Usages:
         The application key is a 40-digit hex number that you can get from
         your account page on backblaze.com.
 
-        Stores an account auth token in ~/.b2_account_info
+        Stores an account auth token in ~/.b2_account_info.  This can be overridden using the
+        B2_ACCOUNT_INFO environment variable.
 
     b2 clear_account
 

--- a/b2
+++ b/b2
@@ -1113,7 +1113,9 @@ class StoredAccountInfo(AbstractAccountInfo):
     DOWNLOAD_URL = 'download_url'
 
     def __init__(self):
-        self.filename = os.path.expanduser('~/.b2_account_info')
+        account_info_filename = os.environ['B2_ACCOUNT_INFO']
+        if account_info_filename is None : account_info_filename = '~/.b2_account_info'
+        self.filename = os.path.expanduser(account_info_filename)
         self.data = self._try_to_read_file()
         if self.BUCKET_UPLOAD_DATA not in self.data:
             self.data[self.BUCKET_UPLOAD_DATA] = {}

--- a/b2
+++ b/b2
@@ -25,7 +25,7 @@ import getpass
 import hashlib
 import httplib
 import json
-import os.path, os.environ
+import os
 import socket
 import stat
 import sys


### PR DESCRIPTION
Running b2 under a low privileged user, such as user nobody, has problems with the credential file.

Typically uses such as these do not have a home directory which means that '~/.b2_account_info' will resolve to '/.b2_account_info'.  This in turn means that the user will require write access to the root directory which is bad.

The solution is to allow the name of the credential file to be overridden using an environment variable 'B2_ACCOUNT_INFO'.  If this variable does not exist, the name will default to '~/.b2_account_info'

Example:
export B2_ACCOUNT_INFO=/tmp/b2_credentials
b2 authorize_account ${ACCT_ID} ${ACCT_KEY}

Thus B2 will store its credentials in the file '/tmp/b2_credentials' rather than the root directory