### PR TITLE
Rethink ThreadPool class.

### DIFF
--- a/b2/thread_pool.py
+++ b/b2/thread_pool.py
@@ -32,11 +32,13 @@ class ThreadInThreadPool(threading.Thread):
         while True:
             task = self.queue.get()
             if task is SHUT_DOWN_TOKEN:
+                self.queue.task_done()
                 return
             try:
                 task.run()
             except Exception as e:
                 self.pool._add_exception((task, e))
+            self.queue.task_done()
 
 
 class ThreadPool(object):
@@ -51,12 +53,18 @@ class ThreadPool(object):
 
     Usage:
         pool = ThreadPool(thread_count=10, queue_capacity=1000)
-        pool.add_task(new MyTask())
-        pool.add_task(new MyTask())
-        pool.join_all()
+        pool.add_task(MyTask(1))
+        pool.add_task(MyTask(2))
+        pool.join()
+
+        pool.add_task(MyTask(3))
+        pool.join()
+
+        pool.shut_down()
+
         errors = pool.get_exceptions()
 
-    Once you call join_all() you may not add any more tasks.
+    This class is THREAD SAFE, so that tasks can add more tasks as they are running.
     """
 
     def __init__(self, thread_count=10, queue_capacity=1000):
@@ -64,33 +72,28 @@ class ThreadPool(object):
         Initializes a new thread pool, starts the threads running,
         and gets ready to accept tasks.
         """
+        self._lock = threading.Lock()  # controls all state
         self._queue = Queue(maxsize=queue_capacity)
         self._threads = [self._start_thread() for i in range(thread_count)]
-        self._lock = threading.Lock()  # controls self.exceptions
         self._exceptions = []
 
     def add_task(self, task):
         """
         Adds a task to the queue, blocking until there is room.
         """
-        self._queue.put(task)
+        with self._lock:
+            self._queue.put(task)
 
-    def join_all(self):
+    def join(self):
         """
         Waits until all tasks are completed and then shuts down the threads.
         """
-        # Tell each of the threads to stop.  Each thread will consume
-        # one of the tokens and then exit.
-        for _ in self._threads:
-            self._queue.put(SHUT_DOWN_TOKEN)
+        # grab the queue in a thread-safe way
+        with self._lock:
+            queue = self._queue
 
-        # Nobody can add any tasks any more.
-        self._queue = None
-
-        # Wait for the threads to be done.
-        for thread in self._threads:
-            thread.join()
-        self._threads = None
+        # wait while not holding the lock, so tasks can add more tasks.
+        queue.join()
 
     def get_exceptions(self):
         """
@@ -99,6 +102,21 @@ class ThreadPool(object):
         """
         with self._lock:
             return self._exceptions
+
+    def shut_down(self):
+        # Nobody can add any tasks any more.
+        with self._lock:
+            queue = self._queue
+            self._queue = None
+
+        # Tell each of the threads to stop.  Each thread will consume
+        # one of the tokens and then exit.
+        for _ in self._threads:
+            queue.put(SHUT_DOWN_TOKEN)
+
+        # Wait for the threads to finish
+        for t in self._threads:
+            t.join()
 
     def _add_exception(self, exception):
         """

--- a/test/test_thread_pool.py
+++ b/test/test_thread_pool.py
@@ -33,13 +33,23 @@ class Counter(object):
 
 
 class TestTask(object):
-    def __init__(self, index, counter):
+    """
+    A simple task that increments a counter.
+
+    Also, adds another task to the queue if this
+    task has an even-numbered index.
+    """
+
+    def __init__(self, pool, index, counter):
+        self.pool = pool
         self.index = index
         self.counter = counter
 
     def run(self):
         if random.randint(1, 5) == 3:
             time.sleep(0.05)
+        if self.index % 2 == 0:
+            self.pool.add_task(TestTask(None, self.index + 1, self.counter))
         new_count = self.counter.increment()
         if new_count == 5:
             raise Exception('five')
@@ -52,9 +62,15 @@ class TestThreadPool(unittest.TestCase):
     def test_it(self):
         pool = ThreadPool(3, 4)
         counter = Counter()
-        for i in range(20):
-            pool.add_task(TestTask(i, counter))
-        pool.join_all()
+        for i in range(0, 10, 2):
+            pool.add_task(TestTask(pool, i, counter))
+        pool.join()
+
+        for i in range(10, 20, 2):
+            pool.add_task(TestTask(pool, i, counter))
+        pool.join()
+
+        pool.shut_down()
         exceptions = pool.get_exceptions()
         self.assertEqual(20, counter.get())
         self.assertEqual(1, len(exceptions))


### PR DESCRIPTION
I think that we'll need to have tasks be able to add tasks
to the queue.  This means that using the shutdown tokens
in join() won't work, because other tasks might get added
behind them.

So the join() method now uses Queue.join().  And there is a
separate shut_down() method that stops the threads after
all of the tasks have been completed.