### PR TITLE
Remove ugly workarounds cause by trying to be compatible with six==1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ python:
 
 matrix:
   include:
-    # OS X on Macs include six=1.4.1, and cannot be upgraded
-    # without expertise, so we support it there.
-    - python: "2.7"
-      env: OLD_SIX=true
     # Source Code Analysis is slow.  We just run it once on
     # Python 2 and once on Python 3.
     - python: "2.7"
@@ -31,7 +27,6 @@ install:
   - pip install mock
   - pip install nose
   - pip install pyflakes
-  - if [ -n "$OLD_SIX" ]; then pip install six==1.4.1; else pip install six==1.10; fi
   - pip install yapf
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ This program provides command-line access to the B2 service.
 
 Version 0.4.9
 
+# Installation
+
+This tool can be installed with:
+
+    pip install b2
+    
+If you see a message saying that the `six` library cannot be installed, which
+happens if you're installing with the system python on OS X El Capitan, try
+this:
+
+    pip install --ignore-installed b2
+
 # Usage
 
     b2 authorize_account [accountId] [applicationKey]

--- a/b2/__init__.py
+++ b/b2/__init__.py
@@ -7,3 +7,20 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+
+# This is a workaround for a problem with OS X El Capitan.  It has
+# six==1.4.1 installed in the system Python, and it cannot be removed.
+# Installing with 'pip install b2 --ignore-installed six' will install
+# the more recent version, but it's put in /Library, which is *after*
+# /System/Library in the path, so it's not found unless the path is
+# reordered.
+#
+# https://github.com/pypa/pip/issues/3165
+# http://apple.stackexchange.com/questions/209572/how-to-use-pip-after-the-el-capitan-max-os-x-upgrade/
+#
+# __init__ is loaded before __main__, so this is the first opportunity
+# we have to adjust the path.
+
+import sys
+if '/Library/Python/2.7/site-packages' in sys.path:
+    sys.path = ['/Library/Python/2.7/site-packages'] + sys.path

--- a/b2/thread_pool.py
+++ b/b2/thread_pool.py
@@ -12,15 +12,8 @@ from __future__ import print_function
 
 import threading
 
-import six
+from six.moves.queue import Queue
 from six.moves import range
-
-# The version of six on OS X (six==1.4.1) does not have queue
-# from six.moves.queue import Queue
-if six.PY2:
-    from Queue import Queue
-else:
-    from queue import Queue
 
 # this is added to the task queue to tell the threads to stop
 SHUT_DOWN_TOKEN = object()

--- a/setup.py
+++ b/setup.py
@@ -81,12 +81,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    #
-    # We would like a more recent version of six, but that makes installation
-    # on OSX El Capitan fail.  OSX has version 1.4.1 built in, and even as
-    # sudo you're not allowed to change the package.  It's locked down.
-    # https://github.com/pypa/pip/issues/3165
-    install_requires=['portalocker>=0.5.7', 'requests>=2.9.1', 'six>=1.4.1'],
+    install_requires=['portalocker>=0.5.7', 'requests>=2.9.1', 'six>=1.10.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/test/test_b2http.py
+++ b/test/test_b2http.py
@@ -17,38 +17,31 @@ import socket
 import sys
 import unittest
 
-# This is seriously ugly.  The version of six that exists on OS X (1.4.1) does not
-# meet the needs of mock, which requires >=1.7.
-six_version = tuple(int(n) for n in six.__version__.split('.'))
-if six_version < (1, 7):
-    HAVE_MOCK = False
+if sys.version_info < (3, 3):
+    from mock import MagicMock
 else:
-    HAVE_MOCK = True
-    if sys.version_info < (3, 3):
-        from mock import MagicMock
-    else:
-        from unittest.mock import MagicMock
+    from unittest.mock import MagicMock
 
 IS_27_OR_LATER = sys.version_info[0] >= 3 or (sys.version_info[0] == 2 and sys.version_info[1] >= 7)
 
 
 class TestTranslateErrors(unittest.TestCase):
     def test_ok(self):
-        if IS_27_OR_LATER and HAVE_MOCK:
+        if IS_27_OR_LATER:
             response = MagicMock()
             response.status_code = 200
             actual = _translate_errors(lambda: response)
             self.assertIs(response, actual)
 
     def test_partial_content(self):
-        if IS_27_OR_LATER and HAVE_MOCK:
+        if IS_27_OR_LATER:
             response = MagicMock()
             response.status_code = 206
             actual = _translate_errors(lambda: response)
             self.assertIs(response, actual)
 
     def test_b2_error(self):
-        if IS_27_OR_LATER and HAVE_MOCK:
+        if IS_27_OR_LATER:
             response = MagicMock()
             response.status_code = 503
             response.content = six.b('{"status": 503, "code": "server_busy", "message": "busy"}')
@@ -56,7 +49,7 @@ class TestTranslateErrors(unittest.TestCase):
                 _translate_errors(lambda: response)
 
     def test_broken_pipe(self):
-        if IS_27_OR_LATER and HAVE_MOCK:
+        if IS_27_OR_LATER:
 
             def fcn():
                 raise requests.ConnectionError(
@@ -68,7 +61,7 @@ class TestTranslateErrors(unittest.TestCase):
                 _translate_errors(fcn)
 
     def test_unknown_host(self):
-        if IS_27_OR_LATER and HAVE_MOCK:
+        if IS_27_OR_LATER:
 
             def fcn():
                 raise requests.ConnectionError(
@@ -80,7 +73,7 @@ class TestTranslateErrors(unittest.TestCase):
                 _translate_errors(fcn)
 
     def test_connection_error(self):
-        if IS_27_OR_LATER and HAVE_MOCK:
+        if IS_27_OR_LATER:
 
             def fcn():
                 raise requests.ConnectionError('a message')
@@ -88,7 +81,7 @@ class TestTranslateErrors(unittest.TestCase):
                 _translate_errors(fcn)
 
     def test_unknown_error(self):
-        if IS_27_OR_LATER and HAVE_MOCK:
+        if IS_27_OR_LATER:
 
             def fcn():
                 raise Exception('a message')
@@ -105,30 +98,27 @@ class TestB2Http(unittest.TestCase):
     PARAMS_JSON_BYTES = six.b('{"fileSize": 100}')
 
     def setUp(self):
-        if HAVE_MOCK:
-            self.requests = MagicMock()
-            self.response = MagicMock()
-            self.b2_http = B2Http(self.requests)
+        self.requests = MagicMock()
+        self.response = MagicMock()
+        self.b2_http = B2Http(self.requests)
 
     def test_post_json_return_json(self):
-        if HAVE_MOCK:
-            self.requests.post.return_value = self.response
-            self.response.status_code = 200
-            self.response.content = six.b('{"color": "blue"}')
-            response_dict = self.b2_http.post_json_return_json(self.URL, self.HEADERS, self.PARAMS)
-            self.assertEqual({'color': 'blue'}, response_dict)
-            self.requests.post.assert_called_with(
-                self.URL,
-                headers=self.EXPECTED_HEADERS,
-                data=self.PARAMS_JSON_BYTES
-            )
+        self.requests.post.return_value = self.response
+        self.response.status_code = 200
+        self.response.content = six.b('{"color": "blue"}')
+        response_dict = self.b2_http.post_json_return_json(self.URL, self.HEADERS, self.PARAMS)
+        self.assertEqual({'color': 'blue'}, response_dict)
+        self.requests.post.assert_called_with(
+            self.URL,
+            headers=self.EXPECTED_HEADERS,
+            data=self.PARAMS_JSON_BYTES
+        )
 
     def test_get_content(self):
-        if HAVE_MOCK:
-            self.requests.get.return_value = self.response
-            self.response.status_code = 200
-            with self.b2_http.get_content(self.URL, self.HEADERS) as r:
-                if IS_27_OR_LATER:
-                    self.assertIs(self.response, r)
-            self.requests.get.assert_called_with(self.URL, headers=self.EXPECTED_HEADERS)
-            self.response.close.assert_called_with()
+        self.requests.get.return_value = self.response
+        self.response.status_code = 200
+        with self.b2_http.get_content(self.URL, self.HEADERS) as r:
+            if IS_27_OR_LATER:
+                self.assertIs(self.response, r)
+        self.requests.get.assert_called_with(self.URL, headers=self.EXPECTED_HEADERS)
+        self.response.close.assert_called_with()


### PR DESCRIPTION
I give up trying to stay compatible.  The installation using the system Python on Macs will just have to be a little different.