### PR TITLE
Fixed multiple InvalidAuthToken errors

### DIFF
--- a/b2/exception.py
+++ b/b2/exception.py
@@ -118,6 +118,9 @@ class InvalidAuthToken(B2Error):
     def __str__(self):
         return 'Invalid authorization token. Server said: %s (%s)' % (self.message, self._type)
 
+    def should_retry_upload(self):
+        return True
+
 
 class MaxFileSizeExceeded(B2Error):
     def __init__(self, size, max_allowed_size):


### PR DESCRIPTION
Fixed some of the errors discussed here #7 

I also changed the InvalidAuthToken exception so that the client retries uploading after such an error. Without this I was still getting errors if I upload very small files and the auth token was invalid.