### PR TITLE
Fix part size decision for really large files.

### DIFF
--- a/b2/utils.py
+++ b/b2/utils.py
@@ -86,10 +86,11 @@ def choose_part_ranges(content_length, minimum_part_size):
     assert minimum_part_size * 2 <= content_length
 
     # How many parts can we make?
-    part_count = content_length // minimum_part_size
+    part_count = min(content_length // minimum_part_size, 10000)
     assert 2 <= part_count
 
-    # All of the parts, except the last, are the same size
+    # All of the parts, except the last, are the same size.  The
+    # last one may be bigger.
     part_size = content_length // part_count
     last_part_size = content_length - (part_size * (part_count - 1))
     assert minimum_part_size <= last_part_size

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -11,12 +11,21 @@
 import b2.utils
 import unittest
 
+import six
+
 
 class TestChooseParts(unittest.TestCase):
     def test_it(self):
         self._check_one([(0, 100), (100, 100)], 200, 100)
         self._check_one([(0, 149), (149, 150)], 299, 100)
         self._check_one([(0, 100), (100, 100), (200, 100)], 300, 100)
+
+        ten_TB = 10 * 1000 * 1000 * 1000 * 1000
+        one_GB = 1000 * 1000 * 1000
+
+        expected = [(i * one_GB, one_GB) for i in six.moves.range(10000)]
+        actual = b2.utils.choose_part_ranges(ten_TB, 100 * 1000 * 1000)
+        self.assertEqual(expected, actual)
 
     def _check_one(self, expected, content_length, min_part_size):
         self.assertEqual(expected, b2.utils.choose_part_ranges(content_length, min_part_size))


### PR DESCRIPTION
Now that the maximum file size is 10TB, the limit of
10,000 parts per file matters when choosing a part size.