### PR TITLE
Prevent running Travis CI twice on each commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ python:
   - 3.5
   - nightly
 
+branches:
+  # https://github.com/travis-ci/travis-ci/issues/1147#issuecomment-160820262
+  only:
+    - master
+
 matrix:
   allow_failures:
     - python: pypy3  # https://github.com/pyca/cryptography/issues/2880


### PR DESCRIPTION
This should not cause any trouble unless we will have conflicting PRs
which target a non-master branch at some time. This never happened yet,
so we are going to cut our Travis usage in half until it does.