### PR TITLE
Return an error code on keyboard interrupts

### DIFF
--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -807,6 +807,7 @@ class ConsoleTool(object):
             return 1
         except KeyboardInterrupt:
             self._print('\nInterrupted.  Shutting down...\n')
+            return 1
 
     def _print(self, *args, **kwargs):
         print(*args, file=self.stdout, **kwargs)


### PR DESCRIPTION
Without this you get the following exception when interrupting the B2 CLI:
```
Interrupted.  Shutting down...

Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/sebi/Desktop/b2_compare/B2_Command_Line_Tool/b2/__main__.py", line 15, in <module>
    main()
  File "/home/sebi/Desktop/b2_compare/B2_Command_Line_Tool/b2/console_tool.py", line 877, in main
    os._exit(exit_status)
TypeError: an integer is required (got type NoneType)
```