### PR TITLE
Restore original requests requirement: >=2.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests>=2.11.0
+requests>=2.9.1
 six>=1.10
 tqdm>=4.5.0


### PR DESCRIPTION
We don't want to specify an exact version, because that increases the probability of incompatibilities with other packages.
