### PR TITLE
sync: handle out-of-order versions

### DIFF
--- a/b2/sync/policy.py
+++ b/b2/sync/policy.py
@@ -220,36 +220,48 @@ def make_b2_keep_days_actions(
     only the 25-day old version can be deleted.  The 15 day-old version
     was visible 10 days ago.
     """
-    prev_age_days = None
-    deleting = False
+    # most recent version older than keepDays (which we must keep to
+    # have a complete snapshot as of keepDays)
+    sentinel = None
+    sentinel_index = None
     for version_index, version in enumerate(dest_file.versions):
         # How old is this version?
         age_days = (now_millis - version.mod_time) / ONE_DAY_IN_MS
-
-        # We assume that the versions are ordered by time, newest first.
-        assert prev_age_days is None or prev_age_days <= age_days
 
         # Do we need to hide this version?
         if version_index == 0 and source_file is None and version.action == 'upload':
             yield B2HideAction(dest_file.name, dest_folder.make_full_path(dest_file.name))
 
-        # Can we start deleting?  Once we start deleting, all older
-        # versions will also be deleted.
-        if version.action == 'hide':
-            if keep_days < age_days:
-                deleting = True
+        # Is the version too new? If so, we must keep it.
+        if age_days <= keep_days:
+            continue
 
-        # Delete this version
-        if deleting:
+        # Even if this version does become the sentinel, we know that it
+        # will be useless to keep a sentinel that is just a "hide"
+        # (because there is nothing behind it to hide). So we can delete
+        # it immediately, but we still need to record it as a sentinel
+        # (because anything older should be deleted immediately, too).
+        if version.action == 'hide':
             yield B2DeleteAction(
                 dest_file.name, dest_folder.make_full_path(dest_file.name), version.id_,
                 make_b2_delete_note(version, version_index, transferred)
             )
 
-        # Can we start deleting with the next version, based on the
-        # age of this one?
-        if keep_days < age_days:
-            deleting = True
-
-        # Remember this age for next time around the loop.
-        prev_age_days = age_days
+        # We become the sentinel node if there isn't one already, or if
+        # we are newer than the previously-found sentinel. In the latter
+        # case, we must dispose of the old sentinel.
+        if sentinel is None:
+            sentinel = version
+            sentinel_index = version_index
+        elif sentinel.mod_time < version.mod_time:
+            yield B2DeleteAction(
+                dest_file.name, dest_folder.make_full_path(dest_file.name), sentinel.id_,
+                make_b2_delete_note(sentinel, sentinel_index, transferred)
+            )
+            sentinel = version
+            sentinel_index = version_index
+        elif version.action != 'hide':
+            yield B2DeleteAction(
+                dest_file.name, dest_folder.make_full_path(dest_file.name), version.id_,
+                make_b2_delete_note(version, version_index, transferred)
+            )

--- a/b2/sync/policy.py
+++ b/b2/sync/policy.py
@@ -189,18 +189,21 @@ class DownAndKeepDaysPolicy(DownPolicy):
     """
     pass
 
+def make_b2_delete_note(version, index, transferred):
+    note = ''
+    if version.action == 'hide':
+        note = '(hide marker)'
+    elif transferred or 0 < index:
+        note = '(old version)'
+    return note
 
 def make_b2_delete_actions(source_file, dest_file, dest_folder, transferred):
     for version_index, version in enumerate(dest_file.versions):
         keep = (version_index == 0) and (source_file is not None) and not transferred
         if not keep:
-            note = ''
-            if version.action == 'hide':
-                note = '(hide marker)'
-            elif transferred or 0 < version_index:
-                note = '(old version)'
             yield B2DeleteAction(
-                dest_file.name, dest_folder.make_full_path(dest_file.name), version.id_, note
+                dest_file.name, dest_folder.make_full_path(dest_file.name), version.id_,
+                make_b2_delete_note(version, version_index, transferred)
             )
 
 
@@ -238,13 +241,9 @@ def make_b2_keep_days_actions(
 
         # Delete this version
         if deleting:
-            note = ''
-            if version.action == 'hide':
-                note = '(hide marker)'
-            elif transferred or 0 < version_index:
-                note = '(old version)'
             yield B2DeleteAction(
-                dest_file.name, dest_folder.make_full_path(dest_file.name), version.id_, note
+                dest_file.name, dest_folder.make_full_path(dest_file.name), version.id_,
+                make_b2_delete_note(version, version_index, transferred)
             )
 
         # Can we start deleting with the next version, based on the

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -414,6 +414,14 @@ class TestMakeSyncActions(unittest.TestCase):
         ]
         self._check_local_to_b2(None, dst_file, FakeArgs(keepDays=2), actions)
 
+    def test_delete_hide_out_of_order(self):
+        dst_file = b2_file('a.txt', [TODAY, TODAY - 4 * DAY, TODAY - 2 * DAY])
+        actions  = [
+            'b2_hide(folder/a.txt)',
+            'b2_delete(folder/a.txt, id_a_8294400000, (old version))',
+        ]
+        self._check_local_to_b2(None, dst_file, FakeArgs(keepDays=1), actions)
+
     def test_already_hidden_multiple_versions_keep(self):
         dst_file = b2_file('a.txt', [-TODAY, TODAY - 2 * DAY, TODAY - 4 * DAY])
         self._check_local_to_b2(None, dst_file, FakeArgs(), [])
@@ -460,6 +468,15 @@ class TestMakeSyncActions(unittest.TestCase):
             'b2_delete(folder/a.txt, id_a_8294400000, (old version))'
         ]
         self._check_local_to_b2(None, dst_file, FakeArgs(delete=True), actions)
+
+    def test_already_hidden_keep_days_out_of_order(self):
+        dst_file = b2_file('a.txt', [-(TODAY - 2 * DAY), TODAY - 6 * DAY, TODAY - 4 * DAY])
+        actions = [
+            'b2_delete(folder/a.txt, id_a_8467200000, (hide marker))',
+            'b2_delete(folder/a.txt, id_a_8121600000, (old version))',
+            'b2_delete(folder/a.txt, id_a_8294400000, (old version))'
+        ]
+        self._check_local_to_b2(None, dst_file, FakeArgs(keepDays=1), actions)
 
     def test_delete_local(self):
         dst_file = local_file('a.txt', [100])


### PR DESCRIPTION
The algorithm for deciding which versions to retain with `--keepDays` requires that the versions be handled in reverse-chronological order. However, this may not be the case if a previous version was added with `--replaceNewer`, which would trigger an assertion.

The goal of the original is to walk backwards and flip on a "deleting" flag, but only _after_ we've walked past the most recent version from before `keepDays` (which itself was the state right _at_ `keepDays`, and should be retained). If our times are out of order, though, we can't rely on a simple flag. Instead, we have to record our current notion of this "sentinel" version to keep, and be ready to replace it if we find something newer.

Fixes #216.
/cc @ppolewicz @bwbeach
