### PR TITLE
pre-commit.sh fixes

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -83,12 +83,7 @@ done
 
 header test_raw_api
 
-if [[ -n "$TEST_ACCOUNT_ID" && -n "$TEST_APPLICATION_KEY" ]]
-then
-    python -m b2.__main__ test_raw_api
-else
-    echo "Skipping because TEST_ACCOUNT_ID and TEST_APPLICATION_KEY are not set"
-fi
+TEST_ACCOUNT_ID="$(head -n 1 ~/.b2_auth)" TEST_APPLICATION_KEY="$(tail -n 1 ~/.b2_auth)" python -m b2.__main__ test_raw_api
 
 if [[ $# -ne 0 && "$1" == quick ]]
 then

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -13,14 +13,6 @@ function header
     echo
 }
 
-if yapf --version &> /dev/null
-then
-    echo "yapf is installed"
-else
-    echo "Please install yapf, then try again."
-    exit 1
-fi
-
 header Unit Tests
 
 if ./run-unit-tests.sh
@@ -32,6 +24,12 @@ else
 fi
 
 header Checking Formatting
+
+if ! type yapf &> /dev/null
+then
+    echo "Please install yapf, then try again."
+    exit 1
+fi
 
 if [ "$(git rev-parse ${base_branch})" != "$(git rev-parse ${base_remote}/${base_remote_branch})" ]; then
     echo """running yapf in full mode, because an assumption that master and origin/master are the same, is broken. To fix it, do this:

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -33,7 +33,7 @@ fi
 
 header Checking Formatting
 
-if [ "$(<.git/refs/heads/${base_branch})" != "$(<.git/refs/remotes/${base_remote}/${base_remote_branch})" ]; then
+if [ "$(git rev-parse ${base_branch})" != "$(git rev-parse ${base_remote}/${base_remote_branch})" ]; then
     echo """running yapf in full mode, because an assumption that master and origin/master are the same, is broken. To fix it, do this:
 git checkout master
 git pull --ff-only

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -93,6 +93,8 @@ then
     exit 0
 fi
 
+header Integration Tests
+
 function run_integration_tests
 {
     if time python test_b2_command_line.py $(head -n 1 ~/.b2_auth) $(tail -n 1 ~/.b2_auth)
@@ -105,7 +107,9 @@ function run_integration_tests
     fi
 }
 
-if [[ -z "$PYTHON_VIRTUAL_ENVS" ]]
+# Check if the variable is set, without triggering an "unbound variable" warning
+# http://stackoverflow.com/a/16753536/95920
+if [[ -z "${PYTHON_VIRTUAL_ENVS:-}" ]]
 then
     run_integration_tests
 else
@@ -117,6 +121,4 @@ else
         set -u
         run_integration_tests
     done
-
 fi
-


### PR DESCRIPTION
I recently started using B2 and thought I would take a crack at helping improving this utility, but I stumbled across a few quirks in the `pre-commit.sh` script, so here's a bunch of fixes that you may or may not like. It's probably easiest to go through the commits one at a time to get the reason for each change.

A thing I have yet to figure out is how to invoke the `quick` option of skipping the integration tests, as it will always collide with how the branch to check against is specified. I was thinking of adding some proper parameter parsing with getopt, but thought it would be a bit much - at least without consulting you guys.