### PR TITLE
Add information about threads and low-bandwidth connections for #228

### DIFF
--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -559,6 +559,10 @@ class Sync(Command):
         console unless '--noProgress' is specified.  A list of
         actions taken is always printed.
 
+        If you have a low-bandwidth connection, running multiple threads
+        will mean that each one has a very low data transfer rate.  With
+        low bandwidth, it's usually better just to use one or two threads.
+
         You can specify --excludeRegex to selectively ignore files that
         match the given pattern. Ignored files will not copy during
         the sync operation. The pattern is a regular expression
@@ -595,6 +599,10 @@ class Sync(Command):
 
         To make the destination exactly match the source, use:
             b2 sync --delete --replaceNewer ... ...
+
+        WARNING: Using '--delete' deletes files!  We recommend not using it.
+        If you use --keepDays instead, that gives you time to recover your
+        files if you discover they are missing on the source end.
 
         To make the destination match the source, but retain previous versions
         for 30 days:


### PR DESCRIPTION
Also, add a warning about using --delete.  A customer lost
files by deleting locally, and then syncing to B2 using --delete.