### PR TITLE
Avoid UnicodeEncodeError on improperly configured terminals

### DIFF
--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -167,7 +167,7 @@ class Command(object):
                 )
             )
             sys.stderr.write("Trying to print: %s\n" % (repr(args),))
-            args = [arg.encode('ascii', 'backslashreplace') for arg in args]
+            args = [arg.encode('ascii', 'backslashreplace').decode() for arg in args]
             descriptor.write(' '.join(args))
         descriptor.write('\n')
 

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -150,30 +150,26 @@ class Command(object):
             arg_parser=self.ARG_PARSER
         )
 
-    def _print(self, *args, **kwargs):
-        self._print_helper(self.stdout, self.stdout.encoding, 'stdout', *args, **kwargs)
+    def _print(self, *args):
+        self._print_helper(self.stdout, self.stdout.encoding, 'stdout', *args)
 
     def _print_stderr(self, *args, **kwargs):
-        self._print_helper(self.stderr, self.stderr.encoding, 'stderr', *args, **kwargs)
+        self._print_helper(self.stderr, self.stderr.encoding, 'stderr', *args)
 
-    def _print_helper(self, descriptor, descriptor_encoding, descriptor_name, *args, **kwargs):
+    def _print_helper(self, descriptor, descriptor_encoding, descriptor_name, *args):
         try:
-            print(*args, file=descriptor, **kwargs)
+            descriptor.write(' '.join(args))
         except UnicodeEncodeError:
-            print(
-                "\nWARNING: Unable to print unicode.  Encoding for %s is: '%s'" % (
+            sys.stderr.write(
+                "\nWARNING: Unable to print unicode.  Encoding for %s is: '%s'\n" % (
                     descriptor_name,
                     descriptor_encoding,
-                ),
-                file=sys.stderr
+                )
             )
-            print("Trying to print: %s" % (repr(args),), file=sys.stderr)
+            sys.stderr.write("Trying to print: %s\n" % (repr(args),))
             args = [arg.encode('ascii', 'backslashreplace') for arg in args]
-            kwargs = dict(
-                (k.encode('ascii', 'backslashreplace'), v.encode('ascii', 'backslashreplace'))
-                for k, v in six.iteritems(kwargs)
-            )
-            print(*args, file=descriptor, **kwargs)
+            descriptor.write(' '.join(args))
+        descriptor.write('\n')
 
     def __str__(self):
         return '%s.%s' % (self.__class__.__module__, self.__class__.__name__)

--- a/b2/sync/report.py
+++ b/b2/sync/report.py
@@ -139,7 +139,7 @@ class SyncReport(object):
                 self.stdout.write(
                     '!WARNING! this terminal cannot properly handle progress reporting'
                 )
-            self.stdout.write(line.encode('ascii', 'backslashreplace'))
+            self.stdout.write(line.encode('ascii', 'backslashreplace').decode())
             logger.warning(
                 'could not output the following line on stdout due to UnicodeEncodeError: %s', line
             )

--- a/b2/sync/report.py
+++ b/b2/sync/report.py
@@ -8,6 +8,7 @@
 #
 ######################################################################
 
+import logging
 import threading
 import time
 
@@ -15,6 +16,8 @@ import six
 
 from ..progress import AbstractProgressListener
 from ..utils import format_and_scale_number, format_and_scale_fraction, raise_if_shutting_down
+
+logger = logging.getLogger(__name__)
 
 
 class SyncReport(object):
@@ -51,6 +54,7 @@ class SyncReport(object):
         self._last_update_time = 0
         self.closed = False
         self.lock = threading.Lock()
+        self.encoding_warning_was_already_printed = False
         self._update_progress()
         self.warnings = []
 
@@ -127,7 +131,18 @@ class SyncReport(object):
         """
         if len(line) < len(self.current_line):
             line += ' ' * (len(self.current_line) - len(line))
-        self.stdout.write(line)
+        try:
+            self.stdout.write(line)
+        except UnicodeEncodeError:
+            if not self.encoding_warning_was_already_printed:
+                self.encoding_warning_was_already_printed = True
+                self.stdout.write(
+                    '!WARNING! this terminal cannot properly handle progress reporting'
+                )
+            self.stdout.write(line.encode('ascii', 'backslashreplace'))
+            logger.warning(
+                'could not output the following line on stdout due to UnicodeEncodeError: %s', line
+            )
         if newline:
             self.stdout.write('\n')
             self.current_line = ''

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -461,8 +461,7 @@ class TestConsoleTool(TestBase):
         """
         expected_stdout = self._trim_leading_spaces(expected_stdout)
         expected_stderr = self._trim_leading_spaces(expected_stderr)
-        stdout = six.StringIO()
-        stderr = six.StringIO()
+        stdout, stderr = self._get_stdouterr()
         console_tool = ConsoleTool(self.b2_api, stdout, stderr)
         actual_status = console_tool.run_command(['b2'] + argv)
 
@@ -481,8 +480,18 @@ class TestConsoleTool(TestBase):
         self.assertEqual(expected_stderr, actual_stderr, 'stderr')
         self.assertEqual(expected_status, actual_status, 'exit status code')
 
+    def _get_stdouterr(self):
+        class MyStringIO(six.StringIO):
+            if six.PY2:  # python3 already has this attribute
+                encoding = 'fake_encoding'
+
+        stdout = MyStringIO()
+        stderr = MyStringIO()
+        return stdout, stderr
+
     def _run_command_no_checks(self, argv):
-        ConsoleTool(self.b2_api, six.StringIO(), six.StringIO()).run_command(['b2'] + argv)
+        stdout, stderr = self._get_stdouterr()
+        ConsoleTool(self.b2_api, stdout, stderr).run_command(['b2'] + argv)
 
     def _trim_leading_spaces(self, s):
         """

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -480,6 +480,13 @@ class TestConsoleTool(TestBase):
         self.assertEqual(expected_stderr, actual_stderr, 'stderr')
         self.assertEqual(expected_status, actual_status, 'exit status code')
 
+    def test_bad_terminal(self):
+        stdout = mock.MagicMock()
+        stdout.write = mock.MagicMock(side_effect=[UnicodeEncodeError('codec', u'foo', 100, 105, 'artificial UnicodeEncodeError')] + list(range(25)))
+        stderr = mock.MagicMock()
+        console_tool = ConsoleTool(self.b2_api, stdout, stderr)
+        console_tool.run_command(['b2', 'authorize_account', 'my-account', 'good-app-key'])
+
     def _get_stdouterr(self):
         class MyStringIO(six.StringIO):
             if six.PY2:  # python3 already has this attribute

--- a/test/test_sync_report.py
+++ b/test/test_sync_report.py
@@ -1,0 +1,28 @@
+######################################################################
+#
+# File: b2/test_sync_report.py
+#
+# Copyright 2016 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+
+from __future__ import print_function
+
+from .test_base import TestBase
+from b2.sync.report import SyncReport
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+
+class TestSyncReport(TestBase):
+    def test_bad_terminal(self):
+        stdout = MagicMock()
+        stdout.write = MagicMock(side_effect=[UnicodeEncodeError('codec', u'foo', 100, 105, 'artificial UnicodeEncodeError')] + list(range(25)))
+        sync_report = SyncReport(stdout, False)
+        sync_report.print_completion('transferred: 123.txt')


### PR DESCRIPTION
I had some trouble in configuring my terminal improperly, so I was not able to test it. Is there a reliable way someone could recommend?