### PR TITLE
Fix #331: assertion failure when syncing

### DIFF
--- a/b2/sync/policy.py
+++ b/b2/sync/policy.py
@@ -240,7 +240,6 @@ def make_b2_keep_days_actions(
     only the 25-day old version can be deleted.  The 15 day-old version
     was visible 10 days ago.
     """
-    prev_age_days = None
     deleting = False
     if dest_file is None:
         # B2 does not really store folders, so there is no need to hide
@@ -250,8 +249,17 @@ def make_b2_keep_days_actions(
         # How old is this version?
         age_days = (now_millis - version.mod_time) / ONE_DAY_IN_MS
 
-        # We assume that the versions are ordered by time, newest first.
-        assert prev_age_days is None or prev_age_days <= age_days
+        # Mostly, the versions are ordered by time, newest first,
+        # BUT NOT ALWAYS.  The mod time we have is the src_last_modified_millis
+        # from the file info (if present), or the upload start time
+        # (if not present).  The user-specified src_last_modified_millis
+        # may not be in order.  Because of that, we no longer
+        # assert that age_days is non-decreasing.
+        #
+        # Note that if there is an out-of-order date that is old enough
+        # to trigger deletions, all of the versions uploaded before that
+        # (the ones after it in the list) will be deleted, even if they
+        # aren't over the age threshold.
 
         # Do we need to hide this version?
         if version_index == 0 and source_file is None and version.action == 'upload':
@@ -275,6 +283,3 @@ def make_b2_keep_days_actions(
         # age of this one?
         if keep_days < age_days:
             deleting = True
-
-        # Remember this age for next time around the loop.
-        prev_age_days = age_days

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -43,7 +43,7 @@ class TestMakeB2KeepDaysActions(TestBase):
         )
 
     def test_old_upload_causes_delete(self):
-        # An upload that is old gets stays if there is a source file, but things
+        # An upload that is old stays if there is a source file, but things
         # behind it go away.
         self.check_one_answer(
             True, [(1, -5, 'upload'), (2, -10, 'upload'), (3, -20, 'upload')],

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -2,7 +2,7 @@
 #
 # File: test_policy
 #
-# Copyright 2017, Backblaze Inc.  All rights reserved.
+# Copyright 2017, Backblaze Inc. All Rights Reserved.
 #
 # License https://www.backblaze.com/using_b2_code.html
 #

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -1,0 +1,77 @@
+######################################################################
+#
+# File: test_policy
+#
+# Copyright 2017, Backblaze Inc.  All rights reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+from b2.sync.file import File, FileVersion
+from b2.sync.folder import B2Folder
+from b2.sync.policy import make_b2_keep_days_actions
+from .test_base import TestBase
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+
+class TestMakeB2KeepDaysActions(TestBase):
+    def setUp(self):
+        self.keep_days = 7
+        self.today = 100 * 86400
+        self.one_day_millis = 86400 * 1000
+
+    def test_no_versions(self):
+        self.check_one_answer(True, [], [])
+
+    def test_new_version_no_action(self):
+        self.check_one_answer(True, [(1, -5, 'upload')], [])
+
+    def test_no_source_one_old_version_hides(self):
+        # An upload that is old gets deleted if there is no source file.
+        self.check_one_answer(False, [(1, -10, 'upload')], ['b2_hide(folder/a)'])
+
+    def test_old_hide_causes_delete(self):
+        # A hide marker that is old gets deleted, as do the things after it.
+        self.check_one_answer(
+            True, [(1, -5, 'upload'), (2, -10, 'hide'), (3, -20, 'upload')],
+            ['b2_delete(folder/a, 2, (hide marker))', 'b2_delete(folder/a, 3, (old version))']
+        )
+
+    def test_old_upload_causes_delete(self):
+        # An upload that is old gets stays if there is a source file, but things
+        # behind it go away.
+        self.check_one_answer(
+            True, [(1, -5, 'upload'), (2, -10, 'upload'), (3, -20, 'upload')],
+            ['b2_delete(folder/a, 3, (old version))']
+        )
+
+    def test_out_of_order_dates(self):
+        # The one at date -3 will get deleted because the one before it is old.
+        self.check_one_answer(
+            True, [(1, -5, 'upload'), (2, -10, 'upload'), (3, -3, 'upload')],
+            ['b2_delete(folder/a, 3, (old version))']
+        )
+
+    def check_one_answer(self, has_source, id_relative_date_action_list, expected_actions):
+        source_file = File('a', []) if has_source else None
+        dest_file_versions = [
+            FileVersion(id_, 'a', self.today + relative_date * self.one_day_millis, action, 100)
+            for (id_, relative_date, action) in id_relative_date_action_list
+        ]
+        dest_file = File('a', dest_file_versions)
+        bucket = MagicMock()
+        api = MagicMock()
+        api.get_bucket_by_name.return_value = bucket
+        dest_folder = B2Folder('bucket-1', 'folder', api)
+        actual_actions = list(
+            make_b2_keep_days_actions(
+                source_file, dest_file, dest_folder, dest_folder, self.keep_days, self.today
+            )
+        )
+        actual_action_strs = [str(a) for a in actual_actions]
+        self.assertEqual(expected_actions, actual_action_strs)


### PR DESCRIPTION
The mod time used for syncing comes from the user-defined src_last_modified_millis,
which isn't guaranteed to be in order.  So I removed the assertion that they are in order.