### PR TITLE
Improve error handling for socket.error that is not 'Broken Pipe'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ before_install:
             else
                 echo skip
             fi
-            export JAVA_OPTS="-Xms1024m -Xmx1024m"
+            export JAVA_OPTS="-Xms128m -Xmx1024m"
             source "$HOME/.virtualenvs/jython/bin/activate"
         else
             echo skip

--- a/b2/b2http.py
+++ b/b2/b2http.py
@@ -68,7 +68,7 @@ def _translate_errors(fcn, post_params=None):
         elif isinstance(e1, requests.packages.urllib3.exceptions.ProtocolError):
             e2 = e1.args[1]
             if isinstance(e2, socket.error):
-                if e2.args[1] == 'Broken pipe':
+                if len(e2.args) >= 2 and e2.args[1] == 'Broken pipe':
                     # Broken pipes are usually caused by the service rejecting
                     # an upload request for cause, so we use a 400 Bad Request
                     # code.


### PR DESCRIPTION
caught at
https://github.com/Backblaze/B2_Command_Line_Tool/issues/350#issuecomment-313848165

I am not catching the actual encountered error worrying about
incompatibility of exception wrappers across various versions of python
and `requests` library.