### PR TITLE
#334: Add prefix_len property to LocalFolder.

### DIFF
--- a/b2/sync/folder.py
+++ b/b2/sync/folder.py
@@ -81,36 +81,20 @@ class LocalFolder(AbstractFolder):
                 https://github.com/Backblaze/B2_Command_Line_Tool/issues/334
 
             Using os.path.abspath, there are three cases to handle here:
-                  * root paths with a drive specification (windows),
-                  * root paths without a drive specification (not windows),
-                  * non root paths
+                  * root paths with a drive specification (windows) -> length=3,
+                  * root paths without a drive specification (not windows) -> length=1,
+                  * non root paths -> length=(len(root) + 1)
 
-            To handle the first two cases, os.path.splitdrive is used to differentiate
-                between platforms.
-
-                >>> import posixpath
-                >>> import ntpath
-                >>> posix_root = '/'
-                >>> nt_root = 'C://'
-                >>> posixpath.splitdrive(posixpath.abspath(posix_root))
-                ('', '/')
-                >>> map(len, _)
-                [0, 1]
-                >>> ntpath.splitdrive(ntpath.abspath(nt_root))
-                ('C:', '\\')
-                >>> map(len, _)
-                [2, 1]
-
-            Furthermore, there is a trailing separator only if the path denotes a root filesystem.
+            Furthermore, there is a trailing separator only if the path denotes a root filesystem,
+                hence following a suggestion from @svonohr and the following SO link:
+                    https://stackoverflow.com/q/2736144/1946984
+                the conjunction of os.path.join(..., '') and os.path.abspath will guarantee
+                that the prefix length includes the trailing separator for both the root path
+                cases and arbitrary paths.
 
         """
 
-        drive, tail = os.path.splitdrive(self.root)
-        if len(tail) == 1:  # If the tail is only one character it must be / or \\
-            # Include the drive if necessary and treat the leading separator as a trailing one.
-            return len(drive) + len(tail)
-        else:
-            return len(self.root) + 1  # include trailing '/' in prefix length
+        return len(os.path.join(self.root, ''))
 
     def folder_type(self):
         return 'local'

--- a/b2/sync/folder_parser.py
+++ b/b2/sync/folder_parser.py
@@ -27,8 +27,6 @@ def parse_sync_folder(folder_name, api):
     elif folder_name.startswith('b2:') and folder_name[3].isalnum():
         return _parse_bucket_and_folder(folder_name[3:], api)
     else:
-        if folder_name.endswith('/'):
-            folder_name = folder_name[:-1]
         return LocalFolder(folder_name)
 
 

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -157,6 +157,25 @@ class TestLocalFolder(TestSync):
             # Verify the prefix length.
             self.assertEqual(folder.prefix_len, expected_prefix_length)
 
+    def test_parse_root_sync_folder(self):
+        """
+
+            A simple test case to verify that `parse_sync_folder` does lets
+                LocalFolder parse the local folder path in order to generate a
+                prefix correctly.
+
+        """
+
+        cwd = os.path.abspath(six.u(os.getcwd()))
+        permutations = [
+            (six.u('/'), u'/'),
+            (six.u('nope'), cwd + six.u(os.path.sep) + u'nope'),
+            (six.u('/nope'), u'/nope')
+        ]
+        for permutation in permutations:
+            ret = parse_sync_folder(permutation[0], None)
+            self.assertEqual(ret.root, permutation[1])
+
 
 class TestB2Folder(TestSync):
     def setUp(self):

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -15,8 +15,8 @@ import platform
 import threading
 import time
 import unittest
-from random import randint, choice
-from string import lowercase
+from random import SystemRandom, choice
+from string import ascii_lowercase
 
 import six
 
@@ -132,7 +132,8 @@ class TestLocalFolder(TestSync):
         prefix = os.path.normpath(u'C://') if platform.system() == 'Windows' else unicode(os.path.sep)
         separator = unicode(os.path.sep)
         root = os.path.normpath(os.getcwdu())  # Always has leading but not trailing separator.
-        relative = u''.join(choice(lowercase) for _ in range(randint(4, 8)))
+        relative = u''.join(choice(ascii_lowercase) for _ in range(SystemRandom().randint(4, 8)))
+
         permutations = {
             prefix: 3 if platform.system() == 'Windows' else 1,  # '/' case
             prefix + relative + separator: len(relative) + 2,  # absolute path with suffix case

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -133,13 +133,13 @@ class TestLocalFolder(TestSync):
         separator = unicode(os.path.sep)
         root = os.path.normpath(os.getcwdu())  # Always has leading but not trailing separator.
         relative = u''.join(choice(lowercase) for _ in range(randint(4, 8)))
-        permutations = dict(**{
+        permutations = {
             prefix: 3 if platform.system() == 'Windows' else 1,  # '/' case
             prefix + relative + separator: len(relative) + 2,  # absolute path with suffix case
             prefix + relative: len(relative) + 2,  # absolute path case
             relative + separator: len(root + relative) + 2,  # relative path with suffix case
             relative: len(root + relative) + 2  # relative path case
-        })
+        }
 
         for base_path, expected_prefix_length in permutations.items():
             # Build a folder.
@@ -149,11 +149,8 @@ class TestLocalFolder(TestSync):
             self.assertEqual(folder.root[folder.prefix_len:], u'')
 
             # Verify full path to relative path conversion.
-            test_path = folder.root
             test_sub_path = u'test'
-            if not folder.root.endswith(separator):
-                test_path += separator
-            test_path += test_sub_path
+            test_path = os.path.join(folder.root, test_sub_path)
             self.assertEqual(test_path[folder.prefix_len:], test_sub_path)
 
             # Verify the prefix length.

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -129,9 +129,9 @@ class TestLocalFolder(TestSync):
 
         """
 
-        prefix = os.path.normpath(u'C://') if platform.system() == 'Windows' else unicode(os.path.sep)
-        separator = unicode(os.path.sep)
-        root = os.path.normpath(os.getcwdu())  # Always has leading but not trailing separator.
+        prefix = os.path.abspath(u'C://') if platform.system() == 'Windows' else six.u(os.path.sep)
+        separator = six.u(os.path.sep)
+        root = os.path.abspath(six.u(os.getcwd()))  # Always has leading but not trailing separator.
         relative = u''.join(choice(ascii_lowercase) for _ in range(SystemRandom().randint(4, 8)))
 
         permutations = {


### PR DESCRIPTION
This PR attempts to resolve an edge case in the prefix length derivation of the LocalFolder class by using `os.path.splitdrive` to generalize cases when the root path is essentially both a leading and trailing delimiter. 

The unit tests are passing for me but I have not been able to test the windows compatibility. If the CI checks pass I will work on getting a VM setup. 