### PR TITLE
Add --compareThreshold and --verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ this:
     b2 ls [--long] [--versions] <bucketName> [<folderName>]
     b2 make-url <fileId>
     b2 sync [--delete] [--keepDays N] [--skipNewer] [--replaceNewer] \
-        [--compareVersions <option>] [--threads N] [--noProgress] \
-        [--excludeRegex <regex> [--includeRegex <regex>]] [--dryRun] \
-        [--allowEmptySource] <source> <destination>
+        [--compareVersions <option>] [--compareThreshold N] \
+        [--threads N] [--noProgress] [--dryRun] [--allowEmptySource] \
+        [--excludeRegex <regex> [--includeRegex <regex>]] \
+        <source> <destination>
     b2 update-bucket [--bucketInfo <json>] [--lifecycleRules <json>] <bucketName> [allPublic | allPrivate]
     b2 upload-file [--sha1 <sha1sum>] [--contentType <contentType>] \
         [--info <key>=<value>]* [--minPartSize N] \
@@ -70,6 +71,8 @@ You can find a [bash completion](https://www.gnu.org/software/bash/manual/html_n
 script in the `contrib` directory. See [this](doc/bash_completion.md) for installation instructions.
 
 ## detailed logs
+
+Verbose logs to stdout can be enabled with the `--verbose` flag.
 
 A hidden flag `--debugLogs` can be used to enable logging to a `b2_cli.log` file (with log rotation at midnight) in current working directory. Please take care to not launch the tool from the directory that you are syncing, or the logs will get synced to the remote server (unless that is really what you want to do).
 

--- a/b2/sync/sync.py
+++ b/b2/sync/sync.py
@@ -260,7 +260,7 @@ def sync_folders(
         for action in make_folder_sync_actions(
             source_folder, dest_folder, args, now_millis, reporter
         ):
-            logging.debug('scheduling action %s on bucket %s')
+            logging.debug('scheduling action %s on bucket %s', action, bucket)
             future = sync_executor.submit(action.run, bucket, reporter, dry_run)
             action_futures.append(future)
             total_files += 1

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -264,6 +264,7 @@ class FakeArgs(object):
         skipNewer=False,
         replaceNewer=False,
         compareVersions=None,
+        compareThreshold=None,
         excludeRegex=None,
         includeRegex=None,
         debugLogs=True,
@@ -275,6 +276,7 @@ class FakeArgs(object):
         self.skipNewer = skipNewer
         self.replaceNewer = replaceNewer
         self.compareVersions = compareVersions
+        self.compareThreshold = compareThreshold
         if excludeRegex is None:
             excludeRegex = []
         self.excludeRegex = excludeRegex


### PR DESCRIPTION
Add `--compareThreshold` to allow deltas in file modTime or size comparisons. Also add `--verbose` for simple verbose (debug) logs to stdout.