### PR TITLE
Fixed off by one issue

### DIFF
--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -277,7 +277,7 @@ class B2RawApi(AbstractRawApi):
                             actual=digest.hexdigest()
                         )
                 else:
-                    desired_length = range_[1] - range_[0]
+                    desired_length = range_[1] - range_[0] + 1
                     if bytes_read != desired_length:
                         raise TruncatedOutput(bytes_read, desired_length)
 


### PR DESCRIPTION
Fixes #377

I don't think a test is really needed since it's checked by this line:
```python
if bytes_read != desired_length:
    raise TruncatedOutput(bytes_read, desired_length)
```