### PR TITLE
Run the latest version of YAPF: 0.19.0

### DIFF
--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -936,8 +936,9 @@ class UploadFile(Command):
             file_infos[parts[0]] = parts[1]
 
         if SRC_LAST_MODIFIED_MILLIS not in file_infos:
-            file_infos[SRC_LAST_MODIFIED_MILLIS
-                      ] = str(int(os.path.getmtime(args.localFilePath) * 1000))
+            file_infos[SRC_LAST_MODIFIED_MILLIS] = str(
+                int(os.path.getmtime(args.localFilePath) * 1000)
+            )
 
         max_workers = args.threads or 10
         self.api.set_thread_pool_size(max_workers)

--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -667,7 +667,9 @@ def test_raw_api_helper(raw_api):
         account_id,
         bucket_id,
         'allPrivate',
-        bucket_info={'color': 'blue'}
+        bucket_info={
+            'color': 'blue'
+        }
     )
     assert updated_bucket['revision'] == 2
 

--- a/test/test_b2http.py
+++ b/test/test_b2http.py
@@ -48,8 +48,9 @@ class TestTranslateErrors(TestBase):
     def test_broken_pipe(self):
         def fcn():
             raise requests.ConnectionError(
-                requests.packages.urllib3.exceptions.
-                ProtocolError("dummy", socket.error(20, 'Broken pipe'))
+                requests.packages.urllib3.exceptions.ProtocolError(
+                    "dummy", socket.error(20, 'Broken pipe')
+                )
             )
 
         with self.assertRaises(BrokenPipe):

--- a/test/test_bucket.py
+++ b/test/test_bucket.py
@@ -396,7 +396,9 @@ class TestUpload(TestCaseWithBucket):
         self._upload_part(large_file_id, 1, data[:part_size])
         progress_listener = StubProgressListener()
         file_info = self.bucket.upload_bytes(
-            data, 'file1', progress_listener=progress_listener, file_infos={'property': 'value1'}
+            data, 'file1', progress_listener=progress_listener, file_infos={
+                'property': 'value1'
+            }
         )
         self.assertEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)
@@ -409,7 +411,9 @@ class TestUpload(TestCaseWithBucket):
         self._upload_part(large_file_id, 1, data[:part_size])
         progress_listener = StubProgressListener()
         file_info = self.bucket.upload_bytes(
-            data, 'file1', progress_listener=progress_listener, file_infos={'property': 'value2'}
+            data, 'file1', progress_listener=progress_listener, file_infos={
+                'property': 'value2'
+            }
         )
         self.assertNotEqual(large_file_id, file_info.id_)
         self._check_file_contents('file1', data)

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -408,7 +408,9 @@ class TestConsoleTool(TestBase):
         auth_token = self.account_info.get_account_auth_token()
         self.raw_api.start_large_file(api_url, auth_token, 'bucket_0', 'file1', 'text/plain', {})
         self.raw_api.start_large_file(
-            api_url, auth_token, 'bucket_0', 'file2', 'text/plain', {'color': 'blue'}
+            api_url, auth_token, 'bucket_0', 'file2', 'text/plain', {
+                'color': 'blue'
+            }
         )
         self.raw_api.start_large_file(
             api_url, auth_token, 'bucket_0', 'file3', 'application/json', {}
@@ -640,8 +642,8 @@ class TestConsoleTool(TestBase):
         # Remove the leading spaces from each line, based on the line
         # with the fewest leading spaces
         leading_spaces = ' ' * space_count
-        assert all(line.startswith(leading_spaces) or line == ''
-                   for line in lines), 'all lines have leading spaces'
+        assert all(line.startswith(leading_spaces) or line == '' for line in lines
+                  ), 'all lines have leading spaces'
         return '\n'.join('' if line == '' else line[space_count:] for line in lines)
 
     def _leading_spaces(self, s):


### PR DESCRIPTION
This will fix build errors caused by YAPF changing it's mind about how code should be formatted.