### PR TITLE
Revert syncing behavior to allow syncing empty folders…

### DIFF
--- a/test_b2_command_line.py
+++ b/test_b2_command_line.py
@@ -23,6 +23,8 @@ import tempfile
 import threading
 import unittest
 
+from b2.console_tool import VERSION_0_COMPATIBILITY
+
 USAGE = """
 This program tests the B2 command-line client.
 
@@ -466,9 +468,13 @@ def _sync_test_using_dir(b2_tool, bucket_name, dir_):
         p = lambda fname: os.path.join(dir_path, fname)
 
         #dir_path is empty so sync should fail unless --allowEmptySource is specified
-        b2_tool.should_fail(
-            ['sync', '--noProgress', dir_path, b2_sync_point], r'Exception: Directory .* is empty'
-        )
+        if VERSION_0_COMPATIBILITY:
+            b2_tool.should_succeed(['sync', '--noProgress', dir_path, b2_sync_point])
+        else:
+            b2_tool.should_fail(
+                ['sync', '--noProgress', dir_path, b2_sync_point],
+                r'Exception: Directory .* is empty'
+            )
 
         b2_tool.should_succeed(
             ['sync', '--noProgress', '--allowEmptySource', dir_path, b2_sync_point]


### PR DESCRIPTION
… when VERSION_0_COMPATIBILITY is set.

This will let us release a 0.7.4 without breaking compatibility.  Then we can turn it back on for a 1.0 release.