### PR TITLE
Adapt to new b2_list_buckets API by explicitly request all buckets.

### DIFF
--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -328,7 +328,13 @@ class B2RawApi(AbstractRawApi):
         )
 
     def list_buckets(self, api_url, account_auth_token, account_id):
-        return self._post_json(api_url, 'b2_list_buckets', account_auth_token, accountId=account_id)
+        return self._post_json(
+            api_url,
+            'b2_list_buckets',
+            account_auth_token,
+            accountId=account_id,
+            bucketTypes=['all']
+        )
 
     def list_file_names(
         self, api_url, account_auth_token, bucket_id, start_file_name=None, max_file_count=None


### PR DESCRIPTION
Starting in November, 2017, some new bucket types will be added, and
the default will be to exclude them from the list of buckets.  The CLI
should show all the buckets.