### PR TITLE
Implemented #404.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ b2.egg-info
 build
 dist
 .eggs/
+venv

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -449,7 +449,7 @@ class GetBucket(Command):
                 else:
                     # `files` is a generator. We don't want to collect all of the values from the
                     # generator, as there many be billions of files in a large bucket.
-                    files = b.ls("", args.bucketName)
+                    files = b.ls("", show_versions=True, recursive=True)
                     # `files` yields tuples of (file_version_info, folder_name). We don't care about
                     # `folder_name`, so just access the first slot of the tuple directly in the
                     # reducer. We can't ask a generator for its size, as the elements are yielded

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -429,7 +429,9 @@ class GetBucket(Command):
 
         If --showSize is specified, then display the number of files
         (fileCount) in the bucket and the aggregate size of all files
-        (totalSize).
+        (totalSize). Note that this entails additional API calls, so
+        will incur additional latency, computation, and Class C
+        transactions.
     """
 
     OPTION_FLAGS = ['showSize']

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -508,6 +508,64 @@ class TestConsoleTool(TestBase):
         '''
         self._run_command(['get-bucket', 'my-bucket'], expected_stdout, '', 0)
 
+    def test_get_bucket_empty_show_size(self):
+        self._authorize_account()
+        self._create_my_bucket()
+        expected_stdout = '''
+        {
+            "accountId": "my-account",
+            "bucketId": "bucket_0",
+            "bucketInfo": {},
+            "bucketName": "my-bucket",
+            "bucketType": "allPublic",
+            "corsRules": [],
+            "fileCount": 0,
+            "lifecycleRules": [],
+            "revision": 1,
+            "totalSize": 0
+        }
+        '''
+        self._run_command(['get-bucket', '--showSize', 'my-bucket'], expected_stdout, '', 0)
+
+    def test_get_bucket_show_size(self):
+        self._authorize_account()
+        self._create_my_bucket()
+        with TempDir() as temp_dir:
+            # Upload a standard test file.
+            local_file1 = self._make_local_file(temp_dir, 'file1.txt')
+            expected_stdout = '''
+            URL by file name: http://download.example.com/file/my-bucket/file1.txt
+            URL by fileId: http://download.example.com/b2api/v1/b2_download_file_by_id?fileId=9999
+            {
+              "action": "upload",
+              "fileId": "9999",
+              "fileName": "file1.txt",
+              "size": 11,
+              "uploadTimestamp": 5000
+            }
+            '''
+            self._run_command(
+                ['upload_file', '--noProgress', 'my-bucket', local_file1, 'file1.txt'],
+                expected_stdout, '', 0
+            )
+
+            # Now check the size information for the bucket.
+            expected_stdout = '''
+            {
+                "accountId": "my-account",
+                "bucketId": "bucket_0",
+                "bucketInfo": {},
+                "bucketName": "my-bucket",
+                "bucketType": "allPublic",
+                "corsRules": [],
+                "fileCount": 1,
+                "lifecycleRules": [],
+                "revision": 1,
+                "totalSize": 11
+            }
+            '''
+            self._run_command(['get-bucket', '--showSize', 'my-bucket'], expected_stdout, '', 0)
+
     def test_sync(self):
         self._authorize_account()
         self._create_my_bucket()


### PR DESCRIPTION
- Added --showSize to get-bucket. Introduces two new fields, fileCount and totalSize, that represent the count of files and the aggregate size of all files, respectively.
- Omission of --showSize results in the original behavior.
- Added venv to .gitignore.

Additional documentation is available in a comment on #404.