### PR TITLE
Reject unusable filenames early (before the server does).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ test:  ## Run unit tests
 .PHONY: clean
 clean: ## Remove stuff you can regenerate
 	rm -rf b2.egg-info build TAGS
-	find . -name \*~ | xargs rm -f
-	find . -name \*.pyc | xargs rm -f
+	find . -name __pycache__ | xargs rm -rf
+	find . -name \*~ -o -name \*.pyc | xargs rm -f

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ setup: ## and enable pre-commit hook for this repo only.
 test:  ## Run unit tests
 	./run-unit-tests.sh
 
+.PHONY:
+format:	## Format code using yapf
+	yapf --verbose --in-place --parallel --recursive --exclude '*eggs/*' .
+
 .PHONY: clean
 clean: ## Remove stuff you can regenerate
 	rm -rf b2.egg-info build TAGS

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ help: ## Show this help.
 
 .PHONY: setup
 setup: ## Set up (to run tests) using your current python environment
+setup: ## and enable pre-commit hook for this repo only.
 	python -m pip install -r requirements-test.txt
+	ln -s $(PWD)/pre-commit.sh .git/hooks/pre-commit || true
 
 .PHONY: test
 test:  ## Run unit tests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+help: ## Show this help.
+	@fgrep -h "##" Makefile | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+	@echo ""
+	@echo "To see doc options, cd to doc and type \"make\""
+
+.PHONY: setup
+setup: ## Set up (to run tests) using your current python environment
+	python -m pip install -r requirements-test.txt
+
+.PHONY: test
+test:  ## Run unit tests
+	./run-unit-tests.sh
+
+.PHONY: clean
+clean: ## Remove stuff you can regenerate
+	rm -rf b2.egg-info build TAGS
+	find . -name \*~ | xargs rm -f
+	find . -name \*.pyc | xargs rm -f

--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ You'll need to have these packages installed:
 
 There is a `Makefile` with a rule to run the unit tests using the currently active Python:
 
+    make setup
     make test
+
+will install the required packages, then run the unit tests.
 
 To test in multiple python virtual environments, set the enviroment variable `PYTHON_VIRTUAL_ENVS`
 to be a space-separated list of their root directories.  When set, the makefile will run the

--- a/b2/b2http.py
+++ b/b2/b2http.py
@@ -19,9 +19,10 @@ import requests
 import six
 import time
 
-from .exception import (B2Error, BadDateFormat, BrokenPipe, B2ConnectionError,
-                        B2RequestTimeout, ClockSkew, ConnectionReset, interpret_b2_error,
-                        UnknownError, UnknownHost)
+from .exception import (
+    B2Error, BadDateFormat, BrokenPipe, B2ConnectionError, B2RequestTimeout, ClockSkew,
+    ConnectionReset, interpret_b2_error, UnknownError, UnknownHost
+)
 from .version import USER_AGENT
 from six.moves import range
 

--- a/b2/b2http.py
+++ b/b2/b2http.py
@@ -19,7 +19,9 @@ import requests
 import six
 import time
 
-from .exception import B2Error, BadDateFormat, BrokenPipe, B2ConnectionError, B2RequestTimeout, ClockSkew, ConnectionReset, interpret_b2_error, UnknownError, UnknownHost
+from .exception import (B2Error, BadDateFormat, BrokenPipe, B2ConnectionError,
+                        B2RequestTimeout, ClockSkew, ConnectionReset, interpret_b2_error,
+                        UnknownError, UnknownHost)
 from .version import USER_AGENT
 from six.moves import range
 

--- a/b2/exception.py
+++ b/b2/exception.py
@@ -223,6 +223,15 @@ class FileNotPresent(B2SimpleError):
     pass
 
 
+class UnusableFileName(B2SimpleError):
+    """Raise when a filename doesn't meet the rules.
+
+    Could possibly use InvalidUploadSource, but this is intended for the filename on the
+    server, which could differ.  https://www.backblaze.com/b2/docs/files.html.
+    """
+    pass
+
+
 class InvalidUploadSource(B2SimpleError):
     pass
 

--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -454,11 +454,13 @@ class B2RawApi(AbstractRawApi):
 
         :param filename: A proposed filename in utf-8.
         :return: None if the filename is usable."""
-        if len(filename) < 1:
+        decoded_filename = filename.decode("utf-8", 'ignore')
+        name_length = len(decoded_filename)
+        if name_length < 1:
             raise UnusableFileName("Filename must be at least 1 character.")
-        if len(filename) > 1024:
+        if name_length > 1024:
             raise UnusableFileName("Filename must be at most 1025 characters.")
-        lowest_unicode_value = ord(min(filename.decode('utf-8', 'ignore')))
+        lowest_unicode_value = ord(min(decoded_filename))
         if lowest_unicode_value < 32:
             message = "Filename \"{}\" contains code {}, which is less than 32.".format(
                 self.unprintable_to_question(filename), lowest_unicode_value
@@ -492,13 +494,8 @@ class B2RawApi(AbstractRawApi):
         :param data_stream: A file like object from which the contents of the file can be read.
         :return:
         """
-        # If the file_name is unusable, don't try to use it for the upload.
-        try:
-            self.check_b2_filename(file_name)
-        except UnusableFileName as e:
-            sys.stderr.write("\nUpload fails.  Exception is:\n{}\n".format(repr(e)))
-            sys.stderr.write("Exiting.\n")
-            os._exit(1)
+        # This will raise UnusableFileName if the file_name doesn't meet the rules.
+        self.check_b2_filename(file_name)
         headers = {
             'Authorization': upload_auth_token,
             'Content-Length': str(content_length),

--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -504,7 +504,7 @@ class B2RawApi(AbstractRawApi):
         :param data_stream: A file like object from which the contents of the file can be read.
         :return:
         """
-        # This will raise UnusableFileName if the file_name doesn't meet the rules.
+        # Raise UnusableFileName if the file_name doesn't meet the rules.
         self.check_b2_filename(file_name)
         headers = {
             'Authorization': upload_auth_token,
@@ -546,7 +546,7 @@ def test_raw_api():
     """
     try:
         raw_api = B2RawApi(B2Http())
-        test_raw_api(raw_api)
+        test_raw_api_helper(raw_api)
         return 0
     except Exception as e:
         print('Caught exception: %s' % (repr(e),), file=sys.stdout)
@@ -565,7 +565,6 @@ def test_raw_api_helper(raw_api):
     this test will break and we'll have to do something about
     it.
     """
-
     account_id = os.environ.get('TEST_ACCOUNT_ID')
     if account_id is None:
         print('TEST_ACCOUNT_ID is not set.', file=sys.stderr)

--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -450,14 +450,18 @@ class B2RawApi(AbstractRawApi):
             **kwargs
         )
 
-    def unprintable_to_hex(self, str):
-        """Replace unprintable chars with a hex representation."""
+    def unprintable_to_hex(self, string):
+        """Replace unprintable chars in string with a hex representation.
+
+        :param string: An arbitrary string, possibly with unprintable characters.
+        :return The string, with unprintable characters changed to hex (e.g., "\x07")
+        """
         unprintables_pattern = re.compile(r'[\x00-\x1f]')
 
         def hexify(match):
             return r'\x{0:02x}'.format(ord(match.group()))
 
-        return unprintables_pattern.sub(hexify, str)
+        return unprintables_pattern.sub(hexify, string)
 
     def check_b2_filename(self, filename):
         """
@@ -466,7 +470,8 @@ class B2RawApi(AbstractRawApi):
         See https://www.backblaze.com/b2/docs/files.html for the rules.
 
         :param filename: A proposed filename in unicode.
-        :return: None if the filename is usable."""
+        :return: None if the filename is usable.
+        """
         encoded_name = filename.encode('utf-8')
         length_in_bytes = len(encoded_name)
         if length_in_bytes < 1:
@@ -793,6 +798,7 @@ def test_raw_api_filename_rules(raw_api):
     - File names cannot start with "/", end with "/", or contain "//".
     - Maximum of 250 bytes of UTF-8 in each segment (part between slashes) of a file name.
     """
+
     def should_be_ok(filename):
         # print(u"    \"{}\" is an OK filename.".format(filename))
         assert raw_api.check_b2_filename(filename) is None
@@ -818,12 +824,12 @@ def test_raw_api_filename_rules(raw_api):
 
     # Check length
     # 1024 bytes is ok if the segments are at most 250 chars.
-    s_1024 = 4*(250*'x' + '/') + 20*'y'
+    s_1024 = 4 * (250 * 'x' + '/') + 20 * 'y'
     should_be_ok(s_1024)
     # 1025 is too long.
     should_raise(s_1024 + u'x')
     # 1024 bytes with two byte characters should also work.
-    s_1024_two_byte = 4*(125*TWO_BYTE_UNICHR + u'/') + 20*u'y'
+    s_1024_two_byte = 4 * (125 * TWO_BYTE_UNICHR + u'/') + 20 * u'y'
     should_be_ok(s_1024_two_byte)
     # But 1025 bytes is too long.
     should_raise(s_1024_two_byte + u'x')
@@ -838,6 +844,6 @@ def test_raw_api_filename_rules(raw_api):
     should_raise(u'not//allowed')
 
     # Reject segments longer than 250 bytes
-    should_raise(u'foo/' + 251*u'x')
+    should_raise(u'foo/' + 251 * u'x')
     # So a segment of 125 two-byte chars plus one should also fail.
-    should_raise(u'foo/' + 125*TWO_BYTE_UNICHR + u'x')
+    should_raise(u'foo/' + 125 * TWO_BYTE_UNICHR + u'x')

--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -472,7 +472,7 @@ class B2RawApi(AbstractRawApi):
             raise UnusableFileName("Filename is too long (can be at most 1024 bytes).")
         lowest_unicode_value = ord(min(filename))
         if lowest_unicode_value < 32:
-            message = "Filename \"{}\" contains code {} (hex {:02x}), less than 32.".format(
+            message = u"Filename \"{}\" contains code {} (hex {:02x}), less than 32.".format(
                 self.unprintable_to_hex(filename), lowest_unicode_value, lowest_unicode_value
             )
             raise UnusableFileName(message)

--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -472,7 +472,7 @@ class B2RawApi(AbstractRawApi):
             raise UnusableFileName("Filename is too long (can be at most 1024 bytes).")
         lowest_unicode_value = ord(min(filename))
         if lowest_unicode_value < 32:
-            message = u"Filename \"{}\" contains code {} (hex {:02x}), less than 32.".format(
+            message = u"Filename \"{0}\" contains code {1} (hex {2:02x}), less than 32.".format(
                 self.unprintable_to_hex(filename), lowest_unicode_value, lowest_unicode_value
             )
             raise UnusableFileName(message)

--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -34,14 +34,6 @@ SRC_LAST_MODIFIED_MILLIS = 'src_last_modified_millis'
 # Special X-Bz-Content-Sha1 value to verify checksum at the end
 HEX_DIGITS_AT_END = 'hex_digits_at_end'
 
-if six.PY3:
-    unichr = chr
-
-# Unicode characters for testing filenames.  (0x0394 is a letter Delta.)
-TWO_BYTE_UNICHR = unichr(0x0394)
-CHAR_UNDER_32 = unichr(31)
-DEL_CHAR = unichr(127)
-
 
 @six.add_metaclass(ABCMeta)
 class AbstractRawApi(object):
@@ -477,7 +469,7 @@ class B2RawApi(AbstractRawApi):
         if length_in_bytes < 1:
             raise UnusableFileName("Filename must be at least 1 character.")
         if length_in_bytes > 1024:
-            raise UnusableFileName("Filename can be at most 1024 bytes.")
+            raise UnusableFileName("Filename is too long (can be at most 1024 bytes).")
         lowest_unicode_value = ord(min(filename))
         if lowest_unicode_value < 32:
             message = "Filename \"{}\" contains code {} (hex {:02x}), less than 32.".format(
@@ -486,14 +478,14 @@ class B2RawApi(AbstractRawApi):
             raise UnusableFileName(message)
         # No DEL for you.
         if '\x7f' in filename:
-            raise UnusableFileName("ASCII DEL (0x7f) not allowed.")
+            raise UnusableFileName("DEL character (0x7f) not allowed.")
         if filename[0] == '/' or filename[-1] == '/':
             raise UnusableFileName("Filename may not start or end with '/'.")
         if '//' in filename:
             raise UnusableFileName("Filename may not contain \"//\".")
         long_segment = max([len(segment.encode('utf-8')) for segment in filename.split('/')])
         if long_segment > 250:
-            raise UnusableFileName("No filename segment may exceed 250 bytes in utf-8.")
+            raise UnusableFileName("Filename segment too long (maximum 250 bytes in utf-8).")
 
     def upload_file(
         self, upload_url, upload_auth_token, file_name, content_length, content_type, content_sha1,
@@ -543,7 +535,7 @@ def test_raw_api():
     """
     Exercises the code in B2RawApi by making each call once, just
     to make sure the parameters are passed in, and the result is
-    passed back.  Also tests the filename rule checker
+    passed back.
 
     The goal is to be a complete test of B2RawApi, so the tests for
     the rest of the code can use the simulator.
@@ -554,8 +546,7 @@ def test_raw_api():
     """
     try:
         raw_api = B2RawApi(B2Http())
-        test_raw_api_filename_rules(raw_api)
-        test_raw_api_helper(raw_api)
+        test_raw_api(raw_api)
         return 0
     except Exception as e:
         print('Caught exception: %s' % (repr(e),), file=sys.stdout)
@@ -784,66 +775,3 @@ def _should_delete_bucket(bucket_name):
     bucket_time = int(match.group(1))
     now = time.time()
     return bucket_time + 3600 <= now
-
-
-def test_raw_api_filename_rules(raw_api):
-    """
-    Test that the filename checker passes conforming names and rejects those that don't.
-
-    From the B2 docs (https://www.backblaze.com/b2/docs/files.html):
-    - Names can be pretty much any UTF-8 string up to 1024 bytes long.
-    - No character codes below 32 are allowed.
-    - Backslashes are not allowed.
-    - DEL characters (127) are not allowed.
-    - File names cannot start with "/", end with "/", or contain "//".
-    - Maximum of 250 bytes of UTF-8 in each segment (part between slashes) of a file name.
-    """
-
-    def should_be_ok(filename):
-        # print(u"    \"{}\" is an OK filename.".format(filename))
-        assert raw_api.check_b2_filename(filename) is None
-
-    def should_raise(filename):
-        # print(u"    \"{}\" is a disallowed filename.".format(filename))
-        try:
-            raw_api.check_b2_filename(filename)
-        except UnusableFileName as e:
-            if six.PY3:
-                msg = e.args[0]
-            else:
-                msg = e.message
-            print("    Rule is:  {}".format(msg))
-            return
-        print(u"    \"{}\" should have been disallowed.".format(filename))
-        assert False
-
-    print("b2 test filename rules")
-    # Examples from doc:
-    should_be_ok('Kitten Videos')
-    should_be_ok(u'\u81ea\u7531.txt')
-
-    # Check length
-    # 1024 bytes is ok if the segments are at most 250 chars.
-    s_1024 = 4 * (250 * 'x' + '/') + 20 * 'y'
-    should_be_ok(s_1024)
-    # 1025 is too long.
-    should_raise(s_1024 + u'x')
-    # 1024 bytes with two byte characters should also work.
-    s_1024_two_byte = 4 * (125 * TWO_BYTE_UNICHR + u'/') + 20 * u'y'
-    should_be_ok(s_1024_two_byte)
-    # But 1025 bytes is too long.
-    should_raise(s_1024_two_byte + u'x')
-
-    # Names with unicode values < 32, and DEL aren't allowed.
-    should_raise(u'hey ' + CHAR_UNDER_32 + u' joe')
-    should_raise(DEL_CHAR)
-
-    # Names can't start or end with '/' or contain '//'
-    should_raise(u'/hey')
-    should_raise(u'hey/')
-    should_raise(u'not//allowed')
-
-    # Reject segments longer than 250 bytes
-    should_raise(u'foo/' + 251 * u'x')
-    # So a segment of 125 two-byte chars plus one should also fail.
-    should_raise(u'foo/' + 125 * TWO_BYTE_UNICHR + u'x')

--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -23,8 +23,9 @@ import six
 
 from .b2http import B2Http
 from .download_dest import DownloadDestBytes
-from .exception import (ChecksumMismatch, TruncatedOutput, UnexpectedCloudBehaviour,
-                        UnusableFileName)
+from .exception import (
+    ChecksumMismatch, TruncatedOutput, UnexpectedCloudBehaviour, UnusableFileName
+)
 from .utils import b2_url_encode, hex_sha1_of_stream
 
 # Standard names for file info entries
@@ -460,7 +461,8 @@ class B2RawApi(AbstractRawApi):
         lowest_unicode_value = ord(min(filename.decode('utf-8', 'ignore')))
         if lowest_unicode_value < 32:
             message = "Filename \"{}\" contains code {}, which is less than 32.".format(
-                self.unprintable_to_question(filename), lowest_unicode_value)
+                self.unprintable_to_question(filename), lowest_unicode_value
+            )
             raise UnusableFileName(message)
         # No DEL for you.
         if '\x7f' in filename:

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -4,7 +4,7 @@ base_remote="${1:-origin}"
 base_branch="${2:-master}"
 base_remote_branch="${3:-master}"
 
-function header 
+function header
 {
     echo
     echo "#"
@@ -39,7 +39,7 @@ git pull --ff-only
 then checkout your topic branch and run $0.
 If the base branch on github is not called 'origin', invoke as $0 proper_origin_remote_name. Then your remote needs to be synched with your master too.
 """
-    yapf --in-place --recursive .
+    yapf --in-place --parallel --recursive --exclude '*eggs/*' .
 else
     echo 'running yapf in incremental mode'
     head=`mktemp`

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 mock
 pyflakes
 yapf
+nose

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[flake8]
+max-line-length=100
+
 [yapf]
 based_on_style=facebook
 COLUMN_LIMIT=100

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -14,7 +14,6 @@ import unittest
 
 
 class TestBase(unittest.TestCase):
-
     @contextmanager
     def assertRaises(self, exc):
         try:

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -14,10 +14,10 @@ import unittest
 
 
 class TestBase(unittest.TestCase):
-
     @contextmanager
     def assertIsNone(self, expr):
         """Fail the test unless the expression is None."""
+        yield
         if expr is not None:
             assert False, '%s is not None' % (repr(expr))
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -14,12 +14,12 @@ import unittest
 
 
 class TestBase(unittest.TestCase):
-    @contextmanager
-    def assertIsNone(self, expr):
+
+    def assertIsNone(self, expr, msg=None):
         """Fail the test unless the expression is None."""
-        yield
         if expr is not None:
-            assert False, '%s is not None' % (repr(expr))
+            standardMsg = '%s is not None' % (repr(expr))
+            assert False, msg or standardMsg
 
     @contextmanager
     def assertRaises(self, exc):

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -14,6 +14,13 @@ import unittest
 
 
 class TestBase(unittest.TestCase):
+
+    @contextmanager
+    def assertIsNone(self, expr):
+        """Fail the test unless the expression is None."""
+        if expr is not None:
+            assert False, '%s is not None' % (repr(expr))
+
     @contextmanager
     def assertRaises(self, exc):
         try:

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -14,11 +14,6 @@ import unittest
 
 
 class TestBase(unittest.TestCase):
-    def assertIsNone(self, expr, msg=None):
-        """Fail the test unless the expression is None."""
-        if expr is not None:
-            standardMsg = '%s is not None' % (repr(expr))
-            assert False, msg or standardMsg
 
     @contextmanager
     def assertRaises(self, exc):

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -14,7 +14,6 @@ import unittest
 
 
 class TestBase(unittest.TestCase):
-
     def assertIsNone(self, expr, msg=None):
         """Fail the test unless the expression is None."""
         if expr is not None:

--- a/test/test_raw_api.py
+++ b/test/test_raw_api.py
@@ -32,7 +32,8 @@ class TestRawAPIFilenames(TestBase):
     def _should_be_ok(self, filename):
         """Call with test filenames that follow the filename rules.
 
-        :param filename: unicode (or str) that follows the rules"""
+        :param filename: unicode (or str) that follows the rules
+        """
         print(u"Filename \"{}\" should be OK".format(filename))
         self.assertIsNone(self.raw_api.check_b2_filename(filename))
 

--- a/test/test_raw_api.py
+++ b/test/test_raw_api.py
@@ -34,7 +34,7 @@ class TestRawAPIFilenames(TestBase):
 
         :param filename: unicode (or str) that follows the rules
         """
-        print(u"Filename \"{}\" should be OK".format(filename))
+        print(u"Filename \"{0}\" should be OK".format(filename))
         self.assertIsNone(self.raw_api.check_b2_filename(filename))
 
     def _should_raise(self, filename, exception_message):
@@ -44,7 +44,7 @@ class TestRawAPIFilenames(TestBase):
         :param exception_message: regexp that matches the exception's detailed message
         """
         print(
-            u"Filename \"{}\" should raise UnusableFileName(\".*{}.*\")."
+            u"Filename \"{0}\" should raise UnusableFileName(\".*{1}.*\")."
             .format(filename, exception_message)
         )
         with self.assertRaisesRegexp(UnusableFileName, exception_message):

--- a/test/test_raw_api.py
+++ b/test/test_raw_api.py
@@ -81,6 +81,8 @@ class TestRawAPIFilenames(TestBase):
 
         # Names with unicode values < 32, and DEL aren't allowed.
         self._should_raise(u'hey' + CHAR_UNDER_32, "contains code.*less than 32")
+        # Unicode in the filename shouldn't break the exception message.
+        self._should_raise(TWO_BYTE_UNICHR + CHAR_UNDER_32, "contains code.*less than 32")
         self._should_raise(DEL_CHAR, "DEL.*not allowed")
 
         # Names can't start or end with '/' or contain '//'

--- a/test/test_raw_api.py
+++ b/test/test_raw_api.py
@@ -11,6 +11,7 @@
 from __future__ import print_function
 
 import six
+import sys
 
 from b2.raw_api import B2RawApi
 from b2.b2http import B2Http
@@ -35,7 +36,7 @@ class TestRawAPIFilenames(TestBase):
         :param filename: unicode (or str) that follows the rules
         """
         print(u"Filename \"{0}\" should be OK".format(filename))
-        self.assertIsNone(self.raw_api.check_b2_filename(filename))
+        assert self.raw_api.check_b2_filename(filename) is None
 
     def _should_raise(self, filename, exception_message):
         """Call with filenames that don't follow the rules (so the rule checker should raise).

--- a/test/test_raw_api.py
+++ b/test/test_raw_api.py
@@ -10,15 +10,12 @@
 
 from __future__ import print_function
 
-import six
+from six import unichr
 
 from b2.raw_api import B2RawApi
 from b2.b2http import B2Http
 from b2.exception import UnusableFileName
 from .test_base import TestBase
-
-if six.PY3:
-    unichr = chr
 
 # Unicode characters for testing filenames.  (0x0394 is a letter Delta.)
 TWO_BYTE_UNICHR = unichr(0x0394)
@@ -35,7 +32,7 @@ class TestRawAPIFilenames(TestBase):
         :param filename: unicode (or str) that follows the rules
         """
         print(u"Filename \"{0}\" should be OK".format(filename))
-        assert self.raw_api.check_b2_filename(filename) is None
+        self.assertIsNone(self.raw_api.check_b2_filename(filename))
 
     def _should_raise(self, filename, exception_message):
         """Call with filenames that don't follow the rules (so the rule checker should raise).

--- a/test/test_raw_api.py
+++ b/test/test_raw_api.py
@@ -1,0 +1,94 @@
+######################################################################
+#
+# File: b2/test_raw_api.py
+#
+# Copyright 2018 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+from __future__ import print_function
+
+import six
+
+from b2.raw_api import B2RawApi
+from b2.b2http import B2Http
+from b2.exception import UnusableFileName
+from .test_base import TestBase
+
+if six.PY3:
+    unichr = chr
+
+# Unicode characters for testing filenames.  (0x0394 is a letter Delta.)
+TWO_BYTE_UNICHR = unichr(0x0394)
+CHAR_UNDER_32 = unichr(31)
+DEL_CHAR = unichr(127)
+
+
+class TestRawAPIFilenames(TestBase):
+    """Test that the filename checker passes conforming names and rejects those that don't."""
+
+    def _should_be_ok(self, filename):
+        """Call with test filenames that follow the filename rules.
+
+        :param filename: unicode (or str) that follows the rules"""
+        print(u"Filename \"{}\" should be OK".format(filename))
+        self.assertIsNone(self.raw_api.check_b2_filename(filename))
+
+    def _should_raise(self, filename, exception_message):
+        """Call with filenames that don't follow the rules (so the rule checker should raise).
+
+        :param filename: unicode (or str) that doesn't follow the rules
+        :param exception_message: regexp that matches the exception's detailed message
+        """
+        print(
+            u"Filename \"{}\" should raise UnusableFileName(\".*{}.*\")."
+            .format(filename, exception_message)
+        )
+        with self.assertRaisesRegexp(UnusableFileName, exception_message):
+            self.raw_api.check_b2_filename(filename)
+
+    def test_b2_filename_checker(self):
+        """Test a conforming and non-conforming filename for each rule.
+
+        From the B2 docs (https://www.backblaze.com/b2/docs/files.html):
+        - Names can be pretty much any UTF-8 string up to 1024 bytes long.
+        - No character codes below 32 are allowed.
+        - Backslashes are not allowed.
+        - DEL characters (127) are not allowed.
+        - File names cannot start with "/", end with "/", or contain "//".
+        - Maximum of 250 bytes of UTF-8 in each segment (part between slashes) of a file name.
+        """
+        print("test b2 filename rules")
+        self.raw_api = B2RawApi(B2Http())
+
+        # Examples from doc:
+        self._should_be_ok('Kitten Videos')
+        self._should_be_ok(u'\u81ea\u7531.txt')
+
+        # Check length
+        # 1024 bytes is ok if the segments are at most 250 chars.
+        s_1024 = 4 * (250 * 'x' + '/') + 20 * 'y'
+        self._should_be_ok(s_1024)
+        # 1025 is too long.
+        self._should_raise(s_1024 + u'x', "too long")
+        # 1024 bytes with two byte characters should also work.
+        s_1024_two_byte = 4 * (125 * TWO_BYTE_UNICHR + u'/') + 20 * u'y'
+        self._should_be_ok(s_1024_two_byte)
+        # But 1025 bytes is too long.
+        self._should_raise(s_1024_two_byte + u'x', "too long")
+
+        # Names with unicode values < 32, and DEL aren't allowed.
+        self._should_raise(u'hey' + CHAR_UNDER_32, "contains code.*less than 32")
+        self._should_raise(DEL_CHAR, "DEL.*not allowed")
+
+        # Names can't start or end with '/' or contain '//'
+        self._should_raise(u'/hey', "not start.*/")
+        self._should_raise(u'hey/', "not .*end.*/")
+        self._should_raise(u'not//allowed', "contain.*//")
+
+        # Reject segments longer than 250 bytes
+        self._should_raise(u'foo/' + 251 * u'x', "segment too long")
+        # So a segment of 125 two-byte chars plus one should also fail.
+        self._should_raise(u'foo/' + 125 * TWO_BYTE_UNICHR + u'x', "segment too long")

--- a/test/test_raw_api.py
+++ b/test/test_raw_api.py
@@ -11,7 +11,6 @@
 from __future__ import print_function
 
 import six
-import sys
 
 from b2.raw_api import B2RawApi
 from b2.b2http import B2Http

--- a/test/test_raw_api.py
+++ b/test/test_raw_api.py
@@ -35,7 +35,7 @@ class TestRawAPIFilenames(TestBase):
         :param filename: unicode (or str) that follows the rules
         """
         print(u"Filename \"{0}\" should be OK".format(filename))
-        self.assertIsNone(self.raw_api.check_b2_filename(filename))
+        self.assertTrue(self.raw_api.check_b2_filename(filename) is None)
 
     def _should_raise(self, filename, exception_message):
         """Call with filenames that don't follow the rules (so the rule checker should raise).

--- a/test/test_raw_api.py
+++ b/test/test_raw_api.py
@@ -26,6 +26,9 @@ DEL_CHAR = unichr(127)
 class TestRawAPIFilenames(TestBase):
     """Test that the filename checker passes conforming names and rejects those that don't."""
 
+    def setUp(self):
+        self.raw_api = B2RawApi(B2Http())
+
     def _should_be_ok(self, filename):
         """Call with test filenames that follow the filename rules.
 
@@ -59,7 +62,6 @@ class TestRawAPIFilenames(TestBase):
         - Maximum of 250 bytes of UTF-8 in each segment (part between slashes) of a file name.
         """
         print("test b2 filename rules")
-        self.raw_api = B2RawApi(B2Http())
 
         # Examples from doc:
         self._should_be_ok('Kitten Videos')


### PR DESCRIPTION
This solves Issue #362 by checking filenames and halting if it finds an unusable filename.  (We can open another issue for what the behavior should be in this case.)

It raises an UnusableFilename exception with appropriate detailed message for filenames that don't meet the rules.

If the problem with a filename is that it has a character code < 32, it includes the offending filename in the exception that it raises, with a "\x00" style hex code in place of the unprintable character(s).

There is a positive and negative unit test for each file rule.
