### PR TITLE
Added more unit tests for get-bucket --showSize.

### DIFF
--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -429,9 +429,12 @@ class GetBucket(Command):
 
         If --showSize is specified, then display the number of files
         (fileCount) in the bucket and the aggregate size of all files
-        (totalSize). Note that this entails additional API calls, so
-        will incur additional latency, computation, and Class C
-        transactions.
+        (totalSize). Hidden files are accounted for in the number of
+        files, but not in the aggregate size. Each version of a file
+        counts as an individual file, and its size contributes toward
+        the aggregate size. Analysis is recursive. Note that this
+        entails additional API calls, so will incur additional latency,
+        computation, and Class C transactions.
     """
 
     OPTION_FLAGS = ['showSize']

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -429,11 +429,13 @@ class GetBucket(Command):
 
         If --showSize is specified, then display the number of files
         (fileCount) in the bucket and the aggregate size of all files
-        (totalSize). Hidden files are accounted for in the number of
-        files, but not in the aggregate size. Each version of a file
-        counts as an individual file, and its size contributes toward
-        the aggregate size. Analysis is recursive. Note that this
-        entails additional API calls, so will incur additional latency,
+        (totalSize). Hidden files and hide markers are accounted for
+        in the reported number of files, and hidden files also
+        contribute toward the reported aggregate size, whereas hide
+        markers do not. Each version of a file counts as an individual
+        file, and its size contributes toward the aggregate size.
+        Analysis is recursive. Note that --showSize requires multiple
+        API calls, and will therefore incur additional latency,
         computation, and Class C transactions.
     """
 

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -527,7 +527,7 @@ class TestConsoleTool(TestBase):
         '''
         self._run_command(['get-bucket', '--showSize', 'my-bucket'], expected_stdout, '', 0)
 
-    def test_get_bucket_show_size(self):
+    def test_get_bucket_one_item_show_size(self):
         self._authorize_account()
         self._create_my_bucket()
         with TempDir() as temp_dir:
@@ -549,7 +549,7 @@ class TestConsoleTool(TestBase):
                 expected_stdout, '', 0
             )
 
-            # Now check the size information for the bucket.
+            # Now check the output of get-bucket against the canon.
             expected_stdout = '''
             {
                 "accountId": "my-account",
@@ -565,6 +565,183 @@ class TestConsoleTool(TestBase):
             }
             '''
             self._run_command(['get-bucket', '--showSize', 'my-bucket'], expected_stdout, '', 0)
+
+    def test_get_bucket_with_versions(self):
+        self._authorize_account()
+        self._create_my_bucket()
+
+        # Put many versions of a file into the test bucket. Unroll the loop here for convenience.
+        bucket = self.b2_api.get_bucket_by_name('my-bucket')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+
+        # Now check the output of get-bucket against the canon.
+        expected_stdout = '''
+        {
+            "accountId": "my-account",
+            "bucketId": "bucket_0",
+            "bucketInfo": {},
+            "bucketName": "my-bucket",
+            "bucketType": "allPublic",
+            "corsRules": [],
+            "fileCount": 10,
+            "lifecycleRules": [],
+            "revision": 1,
+            "totalSize": 40
+        }
+        '''
+        self._run_command(['get-bucket', '--showSize', 'my-bucket'], expected_stdout, '', 0)
+
+    def test_get_bucket_with_folders(self):
+        self._authorize_account()
+        self._create_my_bucket()
+
+        # Create a hierarchical structure within the test bucket. Unroll the loop here for
+        # convenience.
+        bucket = self.b2_api.get_bucket_by_name('my-bucket')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/4/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/4/5/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/4/5/6/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/4/5/6/7/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/4/5/6/7/8/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/4/5/6/7/8/9/test')
+        bucket.upload(UploadSourceBytes(b'check'), 'check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/4/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/4/5/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/4/5/6/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/4/5/6/7/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/4/5/6/7/8/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/4/5/6/7/8/9/check')
+
+        # Now check the output of get-bucket against the canon.
+        expected_stdout = '''
+        {
+            "accountId": "my-account",
+            "bucketId": "bucket_0",
+            "bucketInfo": {},
+            "bucketName": "my-bucket",
+            "bucketType": "allPublic",
+            "corsRules": [],
+            "fileCount": 20,
+            "lifecycleRules": [],
+            "revision": 1,
+            "totalSize": 90
+        }
+        '''
+        self._run_command(['get-bucket', '--showSize', 'my-bucket'], expected_stdout, '', 0)
+
+    def test_get_bucket_with_hidden(self):
+        self._authorize_account()
+        self._create_my_bucket()
+
+        # Put some files into the test bucket. Unroll the loop for convenience.
+        bucket = self.b2_api.get_bucket_by_name('my-bucket')
+        bucket.upload(UploadSourceBytes(b'test'), 'upload1')
+        bucket.upload(UploadSourceBytes(b'test'), 'upload2')
+        bucket.upload(UploadSourceBytes(b'test'), 'upload3')
+        bucket.upload(UploadSourceBytes(b'test'), 'upload4')
+        bucket.upload(UploadSourceBytes(b'test'), 'upload5')
+        bucket.upload(UploadSourceBytes(b'test'), 'upload6')
+
+        # Hide some new files. Don't check the results here; it will be clear enough that
+        # something has failed if the output of 'get-bucket' does not match the canon.
+        stdout, stderr = self._get_stdouterr()
+        console_tool = ConsoleTool(self.b2_api, stdout, stderr)
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', 'hidden1'])
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', 'hidden2'])
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', 'hidden3'])
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', 'hidden4'])
+
+        # Now check the output of get-bucket against the canon.
+        expected_stdout = '''
+        {
+            "accountId": "my-account",
+            "bucketId": "bucket_0",
+            "bucketInfo": {},
+            "bucketName": "my-bucket",
+            "bucketType": "allPublic",
+            "corsRules": [],
+            "fileCount": 10,
+            "lifecycleRules": [],
+            "revision": 1,
+            "totalSize": 24
+        }
+        '''
+        self._run_command(['get-bucket', '--showSize', 'my-bucket'], expected_stdout, '', 0)
+
+    def test_get_bucket_complex(self):
+        self._authorize_account()
+        self._create_my_bucket()
+
+        # Create a hierarchical structure within the test bucket. Unroll the loop here for
+        # convenience.
+        bucket = self.b2_api.get_bucket_by_name('my-bucket')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), 'test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/test')
+        bucket.upload(UploadSourceBytes(b'test'), '1/2/3/test')
+        bucket.upload(UploadSourceBytes(b'check'), 'check')
+        bucket.upload(UploadSourceBytes(b'check'), 'check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/4/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/4/check')
+        bucket.upload(UploadSourceBytes(b'check'), '1/2/3/4/check')
+
+        # Hide some new files. Don't check the results here; it will be clear enough that
+        # something has failed if the output of 'get-bucket' does not match the canon.
+        stdout, stderr = self._get_stdouterr()
+        console_tool = ConsoleTool(self.b2_api, stdout, stderr)
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', '1/hidden1'])
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', '1/hidden1'])
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', '1/hidden2'])
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', '1/2/hidden3'])
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', '1/2/hidden3'])
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', '1/2/hidden3'])
+        console_tool.run_command(['b2', 'hide_file', 'my-bucket', '1/2/hidden3'])
+
+        # Now check the output of get-bucket against the canon.
+        expected_stdout = '''
+        {
+            "accountId": "my-account",
+            "bucketId": "bucket_0",
+            "bucketInfo": {},
+            "bucketName": "my-bucket",
+            "bucketType": "allPublic",
+            "corsRules": [],
+            "fileCount": 29,
+            "lifecycleRules": [],
+            "revision": 1,
+            "totalSize": 99
+        }
+        '''
+        self._run_command(['get-bucket', '--showSize', 'my-bucket'], expected_stdout, '', 0)
 
     def test_sync(self):
         self._authorize_account()


### PR DESCRIPTION
- Improved documentation to describe behavior with respect to hidden files, versions, and hierarchical structures.
- Renamed test_get_bucket_show_size() to test_get_bucket_one_item_show_size().
- Added test_get_bucket_with_versions() (to check behavior wrt to multiple versions).
- Added test_get_bucket_with_folders() (to check behavior wrt to folders).
- Added test_get_bucket_with_hidden() (to check behavior wrt to hidden files).
- Added test_get_bucket_complex() (to check everything together).

All tests pass.