### PR TITLE
Fixes #427

### DIFF
--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -107,10 +107,15 @@ class TestLocalFolder(TestSync):
     def test_invalid_permissions(self):
         with TempDir() as tmpdir:
             folder = self._prepare_folder(tmpdir, invalid_permissions=True)
-            self.assertEqual(self.NAMES[1:], list(f.name for f in folder.all_files(self.reporter)))
-            self.reporter.local_permission_error.assert_called_once_with(
-                os.path.join(tmpdir, self.NAMES[0])
-            )
+            if not os.access(os.path.join(tmpdir, self.NAMES[0]), os.R_OK):
+                self.assertEqual(
+                    self.NAMES[1:], list(f.name for f in folder.all_files(self.reporter))
+                )
+                self.reporter.local_permission_error.assert_called_once_with(
+                    os.path.join(tmpdir, self.NAMES[0])
+                )
+            else:
+                self.assertEqual(self.NAMES, list(f.name for f in folder.all_files(self.reporter)))
 
     def _check_file_filters_results(self, policies_manager, expected_scan_results):
         with TempDir() as tmpdir:

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -107,6 +107,10 @@ class TestLocalFolder(TestSync):
     def test_invalid_permissions(self):
         with TempDir() as tmpdir:
             folder = self._prepare_folder(tmpdir, invalid_permissions=True)
+            # tests differ depending on the user running them. "root" will
+            # succeed in os.access(path, os.R_OK) even if the permissions of
+            # the file are 0 as implemented on self._prepare_folder().
+            # use-case: running test suite inside a docker container
             if not os.access(os.path.join(tmpdir, self.NAMES[0]), os.R_OK):
                 self.assertEqual(
                     self.NAMES[1:], list(f.name for f in folder.all_files(self.reporter))


### PR DESCRIPTION
This PR fixes the relevant test so it behaves differently based on the file access permissions the current user running the test has. As discussed on the issue, it does **not** change `b2/utils.py` anymore as the behaviour there is as intended. If this PR is merged, it closes #427.

N.B.: This time I did run the `./pre-commit.sh` script and it marked:

```text
ALL OK
      231.96 real        51.38 user        13.45 sys
integration tests passed
```

There were no changes to actual source code though, which I then committed to create this PR.