### PR TITLE
Update appveyor build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,75 +9,39 @@ environment:
 
   matrix:
 
-    # Python 2.7.10 is the latest version and is not pre-installed.
+    # Python names come from: https://www.appveyor.com/docs/build-environment/#python
 
-    #- PYTHON: "C:\\Python27.10"
-    #  PYTHON_VERSION: "2.7.10"
-    #  PYTHON_ARCH: "32"
-
-    #- PYTHON: "C:\\Python27.10-x64"
-    #  PYTHON_VERSION: "2.7.10"
-    #  PYTHON_ARCH: "64"
-
-    # Pre-installed Python versions, which Appveyor may upgrade to
-    # a later point release.
-    # See: http://www.appveyor.com/docs/installed-software#python
-
-    #- PYTHON: "C:\\Python27"
-    #  PYTHON_VERSION: "2.7.x" # currently 2.7.9
-    #  PYTHON_ARCH: "32"
-
-    #- PYTHON: "C:\\Python27-x64"
-    #  PYTHON_VERSION: "2.7.x" # currently 2.7.9
-    #  PYTHON_ARCH: "64"
-
-    #- PYTHON: "C:\\Python33"
-    #  PYTHON_VERSION: "3.3.x" # currently 3.3.5
-    #  PYTHON_ARCH: "32"
-
-    #- PYTHON: "C:\\Python33-x64"
-    #  PYTHON_VERSION: "3.3.x" # currently 3.3.5
-    #  PYTHON_ARCH: "64"
-
-    #- PYTHON: "C:\\Python34"
-    #  PYTHON_VERSION: "3.4.x" # currently 3.4.3
-    #  PYTHON_ARCH: "32"
-
-    #- PYTHON: "C:\\Python34-x64"
-    #  PYTHON_VERSION: "3.4.x" # currently 3.4.3
-    #  PYTHON_ARCH: "64"
-
-    # Python versions not pre-installed
-
-    # Python 2.6.6 is the latest Python 2.6 with a Windows installer
-    # See: https://github.com/ogrisel/python-appveyor-demo/issues/10
-
-    - PYTHON: "C:\\Python266"
+    - PYTHON: "C://Python26"
       PYTHON_VERSION: "2.6.6"
       PYTHON_ARCH: "32"
 
-    #- PYTHON: "C:\\Python266-x64"
-    #  PYTHON_VERSION: "2.6.6"
-    #  PYTHON_ARCH: "64"
-
-    #- PYTHON: "C:\\Python35"
-    #  PYTHON_VERSION: "3.5.0"
-    #  PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.0"
+    - PYTHON: "C://Python26-x64"
+      PYTHON_VERSION: "2.6.6"
       PYTHON_ARCH: "64"
 
-    # Major and minor releases (i.e x.0.0 and x.y.0) prior to 3.3.0 use
-    # a different naming scheme.
+    - PYTHON: "C://Python27"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
 
-    #- PYTHON: "C:\\Python270"
-    #  PYTHON_VERSION: "2.7.0"
-    #  PYTHON_ARCH: "32"
+    - PYTHON: "C://Python27-x64"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
 
-    #- PYTHON: "C:\\Python270-x64"
-    #  PYTHON_VERSION: "2.7.0"
-    #  PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
 
 install:
   - ECHO "Filesystem root:"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,13 +11,8 @@ environment:
 
     # Python names come from: https://www.appveyor.com/docs/build-environment/#python
 
-    - PYTHON: "C://Python26"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C://Python26-x64"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "64"
+    # Python 2.6 does not work any more.  It gets errors installing arrow.
+    # I'm not going to take the time right now to figure out why.
 
     - PYTHON: "C://Python27"
       PYTHON_VERSION: "2.7"


### PR DESCRIPTION
Use python names from appveyor web site.

Exclude 2.6, which doesn't work.