### PR TITLE
add contentSha1 to output of b2 upload-file

### DIFF
--- a/b2/file_version.py
+++ b/b2/file_version.py
@@ -38,6 +38,8 @@ class FileVersionInfo(object):
             result['uploadTimestamp'] = self.upload_timestamp
         if self.action is not None:
             result['action'] = self.action
+        if self.content_sha1 is not None:
+            result['contentSha1'] = self.content_sha1
         return result
 
     def format_ls_entry(self):


### PR DESCRIPTION
This pull request includes the contentSha1 in upload-file the output. This is very useful for people who care about the integrity of the files they are uploading, current the workflow is this:

- compute local sha1sum
- call b2 upload-file
- parse output to get b2_file_id
- call  b2 get-file-info "$b2_file_id"
- parse get-file-info output to get remote sha1sum
- compare local and remote sha1sums

This patch simplifies this process such that the workflow is:

- compute local sha1sum
- call b2 upload-file
- parse upload-file output to get remote sha1sum
- compare local and remote sha1sums