### PR TITLE
The testing package is called test, not tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+    packages=find_packages(exclude=['contrib', 'docs', 'test']),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:


### PR DESCRIPTION
setup.py excludes certain packages from deployment, including `tests`. However the test package in b2 is called `test` not `tests` (no s).