### PR TITLE
Adding support for Application Key API's

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ this:
     b2 cancel-large-file <fileId>
     b2 clear-account
     b2 create-bucket [--bucketInfo <json>] [--corsRules <json>] [--lifecycleRules <json>] <bucketName> [allPublic | allPrivate]
-    b2 create-key [--duration <validDurationSeconds>] [--bucket <bucketId>] [--prefix <namePrefix>]
+    b2 create-key [--duration <validDurationSeconds>] [--bucket <bucketName>] [--prefix <namePrefix>] <capabilities> <keyName>
     b2 delete-bucket <bucketName>
     b2 delete-file-version [<fileName>] <fileId>
     b2 delete-key <applicationKeyId>
@@ -41,7 +41,7 @@ this:
     b2 list-buckets
     b2 list-file-names <bucketName> [<startFileName>] [<maxToShow>]
     b2 list-file-versions <bucketName> [<startFileName>] [<startFileId>] [<maxToShow>]
-    b2 list-keys [--keyCount <maxKeyCount>] [--startKey <startApplicationKeyId>]
+    b2 list-keys
     b2 list-parts <largeFileId>
     b2 list-unfinished-large-files <bucketName>
     b2 ls [--long] [--versions] [--recursive] <bucketName> [<folderName>]

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ this:
     b2 cancel-large-file <fileId>
     b2 clear-account
     b2 create-bucket [--bucketInfo <json>] [--corsRules <json>] [--lifecycleRules <json>] <bucketName> [allPublic | allPrivate]
+    b2 create-key [--duration <validDurationSeconds>] [--bucket <bucketId>] [--prefix <namePrefix>]
     b2 delete-bucket <bucketName>
     b2 delete-file-version [<fileName>] <fileId>
+    b2 delete-key <applicationKeyId>
     b2 download-file-by-id [--noProgress] <fileId> <localFileName>
     b2 download-file-by-name [--noProgress] <bucketName> <fileName> <localFileName>
     b2 get-account-info
-    b2 get-bucket <bucketName>
+    b2 get-bucket [--showSize] <bucketName>
     b2 get-download-auth [--prefix <fileNamePrefix>] [--duration <durationInSeconds>] <bucketName>
     b2 get-download-url-with-auth [--duration <durationInSeconds>] <bucketName> <fileName>
     b2 get-file-info <fileId>
@@ -39,14 +41,16 @@ this:
     b2 list-buckets
     b2 list-file-names <bucketName> [<startFileName>] [<maxToShow>]
     b2 list-file-versions <bucketName> [<startFileName>] [<startFileId>] [<maxToShow>]
+    b2 list-keys [--keyCount <maxKeyCount>] [--startKey <startApplicationKeyId>]
     b2 list-parts <largeFileId>
     b2 list-unfinished-large-files <bucketName>
-    b2 ls [--long] [--versions] <bucketName> [<folderName>]
+    b2 ls [--long] [--versions] [--recursive] <bucketName> [<folderName>]
     b2 make-url <fileId>
     b2 sync [--delete] [--keepDays N] [--skipNewer] [--replaceNewer] \
         [--compareVersions <option>] [--compareThreshold N] \
         [--threads N] [--noProgress] [--dryRun ] [--allowEmptySource ] \
         [--excludeRegex <regex> [--includeRegex <regex>]] \
+        [--excludeDirRegex <regex>] \
         <source> <destination>
     b2 update-bucket [--bucketInfo <json>] [--corsRules <json>] [--lifecycleRules <json>] <bucketName> [allPublic | allPrivate]
     b2 upload-file [--sha1 <sha1sum>] [--contentType <contentType>] \

--- a/b2/api.py
+++ b/b2/api.py
@@ -283,10 +283,12 @@ class B2Api(object):
         response = self.session.delete_key(application_key_id=application_key_id)
         return response
 
-    def list_keys(self):
+    def list_keys(self, start_application_key_id=None):
         account_id = self.account_info.get_account_id()
 
-        return self.session.list_keys(account_id)
+        return self.session.list_keys(
+            account_id, max_key_count=1000, start_application_key_id=start_application_key_id
+        )
 
     # other
     def get_file_info(self, file_id):

--- a/b2/api.py
+++ b/b2/api.py
@@ -283,14 +283,10 @@ class B2Api(object):
         response = self.session.delete_key(application_key_id=application_key_id)
         return response
 
-    def list_keys(self, max_key_count=None, start_application_key_id=None):
+    def list_keys(self):
         account_id = self.account_info.get_account_id()
 
-        return self.session.list_keys(
-            account_id,
-            max_key_count=max_key_count,
-            start_application_key_id=start_application_key_id
-        )
+        return self.session.list_keys(account_id)
 
     # other
     def get_file_info(self, file_id):

--- a/b2/api.py
+++ b/b2/api.py
@@ -258,6 +258,40 @@ class B2Api(object):
             self.account_info.get_download_url(), bucket_name, b2_url_encode(file_name)
         )
 
+    # keys
+    def create_key(
+        self, capabilities, key_name, valid_duration_seconds=None, bucket_id=None, name_prefix=None
+    ):
+        account_id = self.account_info.get_account_id()
+
+        response = self.session.create_key(
+            account_id,
+            capabilities=capabilities,
+            key_name=key_name,
+            valid_duration_seconds=valid_duration_seconds,
+            bucket_id=bucket_id,
+            name_prefix=name_prefix
+        )
+
+        assert response['capabilities'] == capabilities
+        assert response['keyName'] == key_name
+
+        return response
+
+    def delete_key(self, application_key_id):
+
+        response = self.session.delete_key(application_key_id=application_key_id)
+        return response
+
+    def list_keys(self, max_key_count=None, start_application_key_id=None):
+        account_id = self.account_info.get_account_id()
+
+        return self.session.list_keys(
+            account_id,
+            max_key_count=max_key_count,
+            start_application_key_id=start_application_key_id
+        )
+
     # other
     def get_file_info(self, file_id):
         """ legacy interface which just returns whatever remote API returns """

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -712,15 +712,42 @@ class ListKeys(Command):
     """
 
     def run(self, args):
-        response = self.api.list_keys()
-
-        self._print('Next Application Key Id: ' + response['nextApplicationKeyId'])
-
-        for key in response['keys']:
-            self._print(
-                '%s  %s  %s' % (key['applicationKeyId'], key['keyName'], key['capabilities'])
-            )
+        self.list_all_keys()
         return 0
+
+    def list_all_keys(self):
+        # make the first call
+        response = self.api.list_keys()
+        next_id = response.get('nextApplicationKeyId')
+
+        # print the first keys
+        self.print_all_keys(response['keys'])
+
+        # do we need to list more keys?
+        has_next = False
+        if next_id:
+            has_next = True
+
+        while has_next:
+            next_response = self.api.list_keys(next_id)
+            self.print_all_keys(next_response['keys'])
+
+            inner_next_id = next_response.get('nextApplicationKeyId')
+
+            if inner_next_id:
+                next_id = inner_next_id
+            else:
+                has_next = False
+
+    def print_all_keys(self, keys_from_response):
+        if keys_from_response:
+            for key in keys_from_response:
+                key_str = '{0}    {1}    {2}'.format(
+                    key['applicationKeyId'], key['keyName'], key['capabilities']
+                )
+                self._print(key_str)
+        else:
+            self._print("No keys from response.")
 
 
 class ListParts(Command):

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -316,8 +316,7 @@ class CreateBucket(Command):
 
 class CreateKey(Command):
     """
-    b2 create-key [--duration <validDurationSeconds>] [--bucket <bucketId>] [--prefix <namePrefix>]
-    <capabilities> <keyName>
+    b2 create-key [--duration <validDurationSeconds>] [--bucket <bucketName>] [--prefix <namePrefix>] <capabilities> <keyName>
 
        Creates a new application key.  Prints the application key information, and is the only time the
        actual application key is returned.
@@ -707,27 +706,19 @@ class ListFileNames(Command):
 
 class ListKeys(Command):
     """
-    b2 list-keys [--keyCount <maxKeyCount>] [--startKey <startApplicationKeyId>]
+    b2 list-keys
 
        Lists the application keys for a given account.
-
-       Optionally sets:
-       - the maximum number of keys returned (the default is 100, the max is 10000).
-       - the first key to return when listing keys
     """
 
-    OPTION_ARGS = ['keyCount', 'startKey']
-
     def run(self, args):
-        response = self.api.list_keys(
-            max_key_count=args.keyCount, start_application_key_id=args.startKey
-        )
+        response = self.api.list_keys()
 
         self._print('Next Application Key Id: ' + response['nextApplicationKeyId'])
 
         for key in response['keys']:
             self._print(
-                '%s  %-10s  %s' % (key['applicationKeyId'], key['keyName'], key['capabilities'])
+                '%s  %s  %s' % (key['applicationKeyId'], key['keyName'], key['capabilities'])
             )
         return 0
 

--- a/b2/raw_simulator.py
+++ b/b2/raw_simulator.py
@@ -441,6 +441,7 @@ class RawSimulator(AbstractRawApi):
 
     MIN_PART_SIZE = 200
 
+    # This is the maximum duration in seconds that an application key can be valid (100 days).
     MAX_DURATION_IN_SECONDS = 86400000
 
     UPLOAD_PART_MATCHER = re.compile('https://upload.example.com/part/([^/]*)')
@@ -656,17 +657,9 @@ class RawSimulator(AbstractRawApi):
         self._assert_account_auth(api_url, account_auth, bucket.account_id)
         return bucket.list_file_versions(start_file_name, start_file_id, max_file_count)
 
-    def list_keys(
-        self, api_url, account_auth_token, account_id, max_key_count, start_application_key_id
-    ):
+    def list_keys(self, api_url, account_auth_token, account_id):
 
         self._assert_account_auth(api_url, account_auth_token, account_id)
-        if max_key_count is not None:
-            if not re.match(r'^[0-9]+$', max_key_count):
-                raise BadJson('illegal key count number: ' + max_key_count)
-            if int(max_key_count) < 1 or int(max_key_count) > 10000:
-                raise BadJson('valid max key count is greater than 0 and less than 10001')
-
         return dict(
             keys=[
                 {

--- a/b2/raw_simulator.py
+++ b/b2/raw_simulator.py
@@ -441,7 +441,7 @@ class RawSimulator(AbstractRawApi):
 
     MIN_PART_SIZE = 200
 
-    # This is the maximum duration in seconds that an application key can be valid (100 days).
+    # This is the maximum duration in seconds that an application key can be valid (1000 days).
     MAX_DURATION_IN_SECONDS = 86400000
 
     UPLOAD_PART_MATCHER = re.compile('https://upload.example.com/part/([^/]*)')
@@ -657,7 +657,14 @@ class RawSimulator(AbstractRawApi):
         self._assert_account_auth(api_url, account_auth, bucket.account_id)
         return bucket.list_file_versions(start_file_name, start_file_id, max_file_count)
 
-    def list_keys(self, api_url, account_auth_token, account_id):
+    def list_keys(
+        self,
+        api_url,
+        account_auth_token,
+        account_id,
+        max_key_count=1000,
+        start_application_key_id=None
+    ):
 
         self._assert_account_auth(api_url, account_auth_token, account_id)
         return dict(
@@ -683,7 +690,7 @@ class RawSimulator(AbstractRawApi):
                         ['listFiles', 'readFiles', 'shareFiles', 'writeFiles', 'deleteFiles']
                 }
             ],
-            nextApplicationKeyId="nextKey"
+            # nextApplicationKeyId="nextKey"
         )
 
     def list_parts(self, api_url, account_auth_token, file_id, start_part_number, max_part_count):

--- a/b2/sync/folder.py
+++ b/b2/sync/folder.py
@@ -193,7 +193,7 @@ class LocalFolder(AbstractFolder):
                 # Check that the file still exists and is accessible, since it can take a long time
                 # to iterate through large folders
                 if is_file_readable(local_path, reporter):
-                    file_mod_time = int(round(os.path.getmtime(local_path) * 1000))
+                    file_mod_time = int(os.path.getmtime(local_path) * 1000)
                     file_size = os.path.getsize(local_path)
                     version = FileVersion(local_path, b2_path, file_mod_time, 'upload', file_size)
                     yield File(b2_path, [version])

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -210,27 +210,11 @@ class TestConsoleTool(TestBase):
 
         # List keys
         expected_list_keys_out = 'Next Application Key Id: nextKey\n' +\
-                                 'applicationKeyOne  KeyOne      [\'listKeys\', \'writeKeys\', \'deleteKeys\']\n' + \
-                                 'applicationKeyTwo  KeyTwo      [\'listBuckets\', \'writeBuckets\', \'deleteBuckets\']\n' +\
-                                 'applicationKeyThree  KeyThree    [\'listFiles\', \'readFiles\', \'shareFiles\', \'writeFiles\', \'deleteFiles\']\n'
+                                 'applicationKeyOne  KeyOne  [\'listKeys\', \'writeKeys\', \'deleteKeys\']\n' + \
+                                 'applicationKeyTwo  KeyTwo  [\'listBuckets\', \'writeBuckets\', \'deleteBuckets\']\n' +\
+                                 'applicationKeyThree  KeyThree  [\'listFiles\', \'readFiles\', \'shareFiles\', \'writeFiles\', \'deleteFiles\']\n'
 
         self._run_command(['list_keys'], expected_list_keys_out, '', 0)
-
-        # List keys with bad key count
-        self._run_command(
-            ['list_keys', '--keyCount', ".)xyz"], '',
-            'ERROR: Bad request: illegal key count number: .)xyz\n', 1
-        )
-
-        self._run_command(
-            ['list_keys', '--keyCount', "0"], '',
-            'ERROR: Bad request: valid max key count is greater than 0 and less than 10001\n', 1
-        )
-
-        self._run_command(
-            ['list_keys', '--keyCount', "19000"], '',
-            'ERROR: Bad request: valid max key count is greater than 0 and less than 10001\n', 1
-        )
 
     def test_bucket_info_from_json(self):
 

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -209,10 +209,9 @@ class TestConsoleTool(TestBase):
         self._run_command(['delete_key', 'abc123'], 'abc123\n', '', 0)
 
         # List keys
-        expected_list_keys_out = 'Next Application Key Id: nextKey\n' +\
-                                 'applicationKeyOne  KeyOne  [\'listKeys\', \'writeKeys\', \'deleteKeys\']\n' + \
-                                 'applicationKeyTwo  KeyTwo  [\'listBuckets\', \'writeBuckets\', \'deleteBuckets\']\n' +\
-                                 'applicationKeyThree  KeyThree  [\'listFiles\', \'readFiles\', \'shareFiles\', \'writeFiles\', \'deleteFiles\']\n'
+        expected_list_keys_out = "applicationKeyOne    KeyOne    ['listKeys', 'writeKeys', 'deleteKeys']\n" \
+                                 "applicationKeyTwo    KeyTwo    ['listBuckets', 'writeBuckets', 'deleteBuckets']\n" \
+                                 "applicationKeyThree    KeyThree    ['listFiles', 'readFiles', 'shareFiles', 'writeFiles', 'deleteFiles']\n"
 
         self._run_command(['list_keys'], expected_list_keys_out, '', 0)
 
@@ -334,8 +333,8 @@ class TestConsoleTool(TestBase):
                     local_download1
                 ], expected_stdout, '', 0
             )
-            self.assertEquals(six.b('hello world'), self._read_file(local_download1))
-            self.assertEquals(mod_time, os.path.getmtime(local_download1))
+            self.assertEqual(six.b('hello world'), self._read_file(local_download1))
+            self.assertEqual(mod_time, os.path.getmtime(local_download1))
 
             # Download file by ID.  (Same expected output as downloading by name)
             local_download2 = os.path.join(temp_dir, 'download2.txt')
@@ -343,7 +342,7 @@ class TestConsoleTool(TestBase):
                 ['download_file_by_id', '--noProgress', '9999', local_download2], expected_stdout,
                 '', 0
             )
-            self.assertEquals(six.b('hello world'), self._read_file(local_download2))
+            self.assertEqual(six.b('hello world'), self._read_file(local_download2))
 
             # Hide the file
             expected_stdout = '''

--- a/test_b2_command_line.py
+++ b/test_b2_command_line.py
@@ -428,7 +428,6 @@ def basic_test(b2_tool, bucket_name):
     b2_tool.should_fail(
         ['authorize_account', sys.argv[1], bad_application_key], r'nvalid authorization'
     )
-    print('######### ' + sys.argv[2])
     b2_tool.should_succeed(['authorize_account', sys.argv[1], sys.argv[2]])
     tearDown_envvar_test('B2_ACCOUNT_INFO')
 

--- a/test_b2_command_line.py
+++ b/test_b2_command_line.py
@@ -63,7 +63,7 @@ def write_file(path, contents):
 
 
 def file_mod_time_millis(path):
-    return int(round(1000 * os.path.getmtime(path)))
+    return int(os.path.getmtime(path) * 1000)
 
 
 def set_file_mod_time_millis(path, time):
@@ -428,6 +428,7 @@ def basic_test(b2_tool, bucket_name):
     b2_tool.should_fail(
         ['authorize_account', sys.argv[1], bad_application_key], r'nvalid authorization'
     )
+    print('######### ' + sys.argv[2])
     b2_tool.should_succeed(['authorize_account', sys.argv[1], sys.argv[2]])
     tearDown_envvar_test('B2_ACCOUNT_INFO')
 


### PR DESCRIPTION
Added the Create, Delete and List Key API's (not yet live) to the command availability.
Add test cases and some local checks in test_console_tool.py.

TODO: add functional testing in test_b2_command_line.py

Also fixed the issue we saw where the timestamp in milliseconds was returned differently for 
sync because we round in the unit tests, and not in sync (we no longer round), which we think
happened because the mac OSX changed the modified timestamp for files.