### PR TITLE
Fix #456 by dropping support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
@@ -70,7 +69,7 @@ matrix:
       env: PYPY_VERSION=pypy3-2.4.0
 
     # test_raw_api takes too long to be run in every cell of the build matrix
-    - python: 2.6
+    - python: 2.7
       env: MODE=TEST_RAW_API
     - python: 3.6
       env: MODE=TEST_RAW_API

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
setuptools dropped support for 3.3 and refuses to
install anything in 3.3, so we're not able to run tests for it.

Also, stop claiming to support 3.3.  "If it's not tested, it doesn't work."

For some reason, setuptools does still support 2.6, which
hasn't had any releases since 2013.  I'm not taking that out
yet.