### PR TITLE
fix tests with Python 3.7

### DIFF
--- a/b2/sync/policy.py
+++ b/b2/sync/policy.py
@@ -247,7 +247,7 @@ def make_b2_delete_actions(source_file, dest_file, dest_folder, transferred):
     if dest_file is None:
         # B2 does not really store folders, so there is no need to hide
         # them or delete them
-        raise StopIteration()
+        return
     for version_index, version in enumerate(dest_file.versions):
         keep = (version_index == 0) and (source_file is not None) and not transferred
         if not keep:
@@ -276,7 +276,7 @@ def make_b2_keep_days_actions(
     if dest_file is None:
         # B2 does not really store folders, so there is no need to hide
         # them or delete them
-        raise StopIteration()
+        return
     for version_index, version in enumerate(dest_file.versions):
         # How old is this version?
         age_days = (now_millis - version.mod_time) / ONE_DAY_IN_MS


### PR DESCRIPTION
PEP 479 changed behavior so that StopIteration does not bubble out of a generator.
Luckily the affected generators can just return immediately instead.