### PR TITLE
Fix raw_api_test

### DIFF
--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1123,8 +1123,7 @@ class TestRawApi(Command):
     PRIVATE = True
 
     def run(self, args):
-        test_raw_api()
-        return 0
+        return test_raw_api()
 
 
 class TestUploadUrlConcurrency(Command):

--- a/b2/raw_api.py
+++ b/b2/raw_api.py
@@ -683,6 +683,7 @@ def test_raw_api_helper(raw_api):
         api_url, account_auth_token, account_id, bucket_name, 'allPublic'
     )
     bucket_id = bucket_dict['bucketId']
+    first_bucket_revision = bucket_dict['revision']
 
     # b2_list_buckets
     print('b2_list_buckets')
@@ -740,7 +741,7 @@ def test_raw_api_helper(raw_api):
     # b2_get_download_authorization
     print('b2_get_download_authorization')
     download_auth = raw_api.get_download_authorization(
-        api_url, account_auth_token, bucket_id, "prefix", 12345
+        api_url, account_auth_token, bucket_id, file_name[:-2], 12345
     )
     download_auth_token = download_auth['authorizationToken']
 
@@ -826,7 +827,7 @@ def test_raw_api_helper(raw_api):
         'allPrivate',
         bucket_info={'color': 'blue'}
     )
-    assert updated_bucket['revision'] == 2
+    assert first_bucket_revision < updated_bucket['revision']
 
     # clean up this test
     _clean_and_delete_bucket(raw_api, api_url, account_auth_token, account_id, bucket_id)

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -97,7 +97,13 @@ done
 
 header test_raw_api
 
-TEST_ACCOUNT_ID="$(head -n 1 ~/.b2_auth)" TEST_APPLICATION_KEY="$(tail -n 1 ~/.b2_auth)" python -m b2.__main__ test_raw_api
+if TEST_ACCOUNT_ID="$(head -n 1 ~/.b2_auth)" TEST_APPLICATION_KEY="$(tail -n 1 ~/.b2_auth)" python -m b2.__main__ test_raw_api
+then
+    echo "raw API test PASSED"
+else
+    echo "raw API test FAILED"
+    exit 1
+fi
 
 if [[ $# -ne 0 && "${4:-}" == quick ]]
 then


### PR DESCRIPTION
There were three problems:

1. The download authorization with file prefix did not match the file being downloaded.
2. The bucket revision test was too picky.  The only promise that the service makes is that updates to a bucket increase the revision number.
3. `pre-commit.sh` was not detecting errors from the `raw_api_test`
