### PR TITLE
List Bucket from allowed field only (if specified)

### DIFF
--- a/b2/api.py
+++ b/b2/api.py
@@ -230,7 +230,14 @@ class B2Api(object):
         """
         account_id = self.account_info.get_account_id()
 
-        response = self.session.list_buckets(account_id)
+        allowed = self.account_info.get_allowed()
+        allowed_bucket_id = allowed['bucketId']
+
+        response = None
+        if allowed_bucket_id is None:
+            response = self.session.list_buckets(account_id)
+        else:
+            response = self.session.list_buckets(account_id, allowed_bucket_id)
 
         buckets = BucketFactory.from_api_response(self, response)
 

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -533,7 +533,7 @@ class GetBucket(Command):
     def run(self, args):
         # This always wants up-to-date info, so it does not use
         # the bucket cache.
-        for b in self.api.list_buckets():
+        for b in self.api.list_buckets(args.bucketName):
             if b.name == args.bucketName:
                 if not args.showSize:
                     self._print(json.dumps(b.bucket_dict, indent=4, sort_keys=True))

--- a/b2/exception.py
+++ b/b2/exception.py
@@ -280,6 +280,14 @@ class InvalidAuthToken(Unauthorized):
               self).__init__('Invalid authorization token. Server said: ' + message, code)
 
 
+class RestrictedBucket(B2Error):
+    def __init__(self, allowed_bucket):
+        self.bucket = allowed_bucket
+
+    def __str__(self):
+        return 'Application key is restricted to bucket: %s' % self.bucket
+
+
 class MaxFileSizeExceeded(B2Error):
     def __init__(self, size, max_allowed_size):
         super(MaxFileSizeExceeded, self).__init__()

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -191,6 +191,7 @@ class TestConsoleTool(TestBase):
 
         self._run_command(['create_bucket', 'my-bucket-a', 'allPublic'], 'bucket_0\n', '', 0)
         self._run_command(['create_bucket', 'my-bucket-b', 'allPublic'], 'bucket_1\n', '', 0)
+        self._run_command(['create_bucket', 'my-bucket-c', 'allPublic'], 'bucket_2\n', '', 0)
 
         capabilities = ['readFiles', 'listBuckets']
         capabilities_with_commas = ','.join(capabilities)
@@ -264,6 +265,69 @@ class TestConsoleTool(TestBase):
 
         self._run_command(['list_keys'], expected_list_keys_out, '', 0)
         self._run_command(['list_keys', '--long'], expected_list_keys_out_long, '', 0)
+
+        # make sure calling list_buckets with one bucket doesn't clear the cache
+        cache_map_before = self.cache.name_id_map
+        self.b2_api.list_buckets('my-bucket-a ')
+        cache_map_after = self.cache.name_id_map
+        assert cache_map_before == cache_map_after
+
+        # authorize and make calls using application key with no restrictions
+        self._run_command(
+            ['authorize_account', 'appKeyId0', 'appKey0'], 'Using http://production.example.com\n',
+            '', 0
+        )
+        self._run_command(
+            ['list-buckets'],
+            'bucket_0  allPublic   my-bucket-a\nbucket_2  allPublic   my-bucket-c\n', '', 0
+        )
+
+        get_bucket_stdout = '''
+        {
+            "accountId": "my-account",
+            "bucketId": "bucket_0",
+            "bucketInfo": {},
+            "bucketName": "my-bucket-a",
+            "bucketType": "allPublic",
+            "corsRules": [],
+            "lifecycleRules": [],
+            "revision": 1
+        }
+        '''
+        self._run_command(['get-bucket', 'my-bucket-a'], get_bucket_stdout, '', 0)
+
+        # authorize and make calls using an application key with bucket restrictions
+        self._run_command(
+            ['authorize_account', 'appKeyId1', 'appKey1'], 'Using http://production.example.com\n',
+            '', 0
+        )
+
+        self._run_command(
+            ['list-buckets'], '', 'ERROR: Application key is restricted to bucket: my-bucket-a\n', 1
+        )
+        self._run_command(
+            ['get-bucket', 'my-bucket-c'], '',
+            'ERROR: Application key is restricted to bucket: my-bucket-a\n', 1
+        )
+
+        expected_get_bucket_stdout = '''
+        {
+            "accountId": "my-account",
+            "bucketId": "bucket_0",
+            "bucketInfo": {},
+            "bucketName": "my-bucket-a",
+            "bucketType": "allPublic",
+            "corsRules": [],
+            "lifecycleRules": [],
+            "revision": 1
+        }
+        '''
+
+        self._run_command(['get-bucket', 'my-bucket-a'], expected_get_bucket_stdout, '', 0)
+        self._run_command(
+            ['list-file-names', 'my-bucket-c'], '',
+            'ERROR: Application key is restricted to bucket: my-bucket-a\n', 1
+        )
 
     def test_bucket_info_from_json(self):
 


### PR DESCRIPTION
This is the fix for allowing us to make the CLI calls which require list buckets specifically when we have an application key that is restricted to a bucket.