### PR TITLE
Separate progress listeners to read and write

### DIFF
--- a/b2/bucket.py
+++ b/b2/bucket.py
@@ -16,7 +16,7 @@ from .exception import (
     AlreadyFailed, B2Error, MaxFileSizeExceeded, MaxRetriesExceeded, UnrecognizedBucketType
 )
 from .file_version import FileVersionInfoFactory
-from .progress import DoNothingProgressListener, AbstractProgressListener, RangeOfInputStream, StreamWithProgress, StreamWithHash
+from .progress import DoNothingProgressListener, AbstractProgressListener, RangeOfInputStream, ReadingStreamWithProgress, StreamWithHash
 from .unfinished_large_file import UnfinishedLargeFile
 from .upload_source import UploadSourceBytes, UploadSourceLocalFile
 from .utils import b2_url_encode, choose_part_ranges, hex_sha1_of_stream, interruptible_get_result, validate_b2_file_name
@@ -407,7 +407,7 @@ class Bucket(object):
 
                 try:
                     with upload_source.open() as file:
-                        input_stream = StreamWithProgress(file, progress_listener)
+                        input_stream = ReadingStreamWithProgress(file, progress_listener)
                         hashing_stream = StreamWithHash(input_stream)
                         length_with_hash = content_length + hashing_stream.hash_size()
                         response = self.api.raw_api.upload_file(
@@ -551,7 +551,7 @@ class Bucket(object):
                     offset, content_length = part_range
                     file.seek(offset)
                     range_stream = RangeOfInputStream(file, offset, content_length)
-                    input_stream = StreamWithProgress(range_stream, part_progress_listener)
+                    input_stream = ReadingStreamWithProgress(range_stream, part_progress_listener)
                     hashing_stream = StreamWithHash(input_stream)
                     length_with_hash = content_length + hashing_stream.hash_size()
                     response = self.api.raw_api.upload_part(

--- a/b2/download_dest.py
+++ b/b2/download_dest.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 import six
 
 from .utils import B2TraceMetaAbstract, limit_trace_arguments
-from .progress import StreamWithProgress
+from .progress import WritingStreamWithProgress
 
 
 @six.add_metaclass(B2TraceMetaAbstract)
@@ -187,4 +187,4 @@ class DownloadDestProgressWrapper(AbstractDownloadDestination):
                 total_bytes = range_[1] - range_[0] + 1
             self.progress_listener.set_total_bytes(total_bytes)
             with self.progress_listener:
-                yield StreamWithProgress(file_, self.progress_listener)
+                yield WritingStreamWithProgress(file_, self.progress_listener)


### PR DESCRIPTION
This is needed because soon we read a part of the file from the drive after it's downloaded, to finish hashing it. Without this, progress showed more than 100%.