### PR TITLE
Use `_have` instead of `have` for bash completion

### DIFF
--- a/contrib/bash_completion/b2
+++ b/contrib/bash_completion/b2
@@ -1,4 +1,4 @@
-have b2 &&
+_have b2 &&
 _b2 () {
     local _b2_subcommands=(
         'authorize_account'


### PR DESCRIPTION
`have` is [deprecated](https://github.com/scop/bash-completion/blob/4d88339928aa064a567d5feb40694dfd24a274c5/bash_completion#L114) and gets unset at the end of
[bash_completion](https://github.com/scop/bash-completion/blob/4d88339928aa064a567d5feb40694dfd24a274c5/bash_completion#L2103) which can cause issues in certain situations
(specifically when running bash_completion on NixOS - because
the script is evaluated at the [start](https://github.com/NixOS/nixpkgs/blob/80b6513fbf5789ff0208c19a89bae49df2b503ad/nixos/modules/programs/bash/bash.nix#L22) but can't finish properly
because `have` is already unset at that point).