### PR TITLE
Fix assertion on bucket name.

### DIFF
--- a/b2/api.py
+++ b/b2/api.py
@@ -223,7 +223,7 @@ class B2Api(object):
 
         # Second, ask the service
         for bucket in self.list_buckets(bucket_name=bucket_name):
-            assert bucket.name == bucket_name
+            assert bucket.name.lower() == bucket_name.lower()
             return bucket
 
         # There is no such bucket.


### PR DESCRIPTION
Bucket names are case-insensitive, so the assertion that the bucket
name coming back from the service matches should be case-insensitive.