### PR TITLE
#390 Exclude symlinks from backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ this:
         [--threads N] [--noProgress] [--dryRun ] [--allowEmptySource ] \
         [--excludeRegex <regex> [--includeRegex <regex>]] \
         [--excludeDirRegex <regex>] \
+        [--excludeSymlinks ] \
         <source> <destination>
     b2 update-bucket [--bucketInfo <json>] [--corsRules <json>] [--lifecycleRules <json>] <bucketName> [allPublic | allPrivate]
     b2 upload-file [--sha1 <sha1sum>] [--contentType <contentType>] \

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ this:
         [--threads N] [--noProgress] [--dryRun ] [--allowEmptySource ] \
         [--excludeRegex <regex> [--includeRegex <regex>]] \
         [--excludeDirRegex <regex>] \
-        [--excludeSymlinks ] \
+        [--excludeAllSymlinks ] \
         <source> <destination>
     b2 update-bucket [--bucketInfo <json>] [--corsRules <json>] [--lifecycleRules <json>] <bucketName> [allPublic | allPrivate]
     b2 upload-file [--sha1 <sha1sum>] [--contentType <contentType>] \

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1016,7 +1016,7 @@ class Sync(Command):
             [--threads N] [--noProgress] [--dryRun ] [--allowEmptySource ] \\
             [--excludeRegex <regex> [--includeRegex <regex>]] \\
             [--excludeDirRegex <regex>] \\
-            [--excludeSymlinks ] \\
+            [--excludeAllSymlinks ] \\
             <source> <destination>
 
         Copies multiple files from source to destination.  Optionally
@@ -1057,7 +1057,7 @@ class Sync(Command):
 
         Note that --includeRegex cannot be used without --excludeRegex.
 
-        You can specify --excludeSymlinks to skip symlinks when
+        You can specify --excludeAllSymlinks to skip symlinks when
         syncing from a local source.
 
         When a directory is excluded by using --excludeDirRegex, all of
@@ -1137,7 +1137,7 @@ class Sync(Command):
 
     OPTION_FLAGS = [
         'delete', 'noProgress', 'skipNewer', 'replaceNewer', 'dryRun', 'allowEmptySource',
-        'excludeSymlinks'
+        'excludeAllSymlinks'
     ]
     OPTION_ARGS = ['keepDays', 'threads', 'compareVersions', 'compareThreshold']
     REQUIRED = ['source', 'destination']
@@ -1161,7 +1161,7 @@ class Sync(Command):
             exclude_dir_regexes=args.excludeDirRegex,
             exclude_file_regexes=args.excludeRegex,
             include_file_regexes=args.includeRegex,
-            exclude_symlinks=args.excludeSymlinks,
+            exclude_all_symlinks=args.excludeAllSymlinks,
         )
         sync_folders(
             source_folder=source,

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1136,8 +1136,13 @@ class Sync(Command):
     """
 
     OPTION_FLAGS = [
-        'delete', 'noProgress', 'skipNewer', 'replaceNewer', 'dryRun', 'allowEmptySource',
-        'excludeAllSymlinks'
+        'delete',
+        'noProgress',
+        'skipNewer',
+        'replaceNewer',
+        'dryRun',
+        'allowEmptySource',
+        'excludeAllSymlinks',
     ]
     OPTION_ARGS = ['keepDays', 'threads', 'compareVersions', 'compareThreshold']
     REQUIRED = ['source', 'destination']

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1136,7 +1136,8 @@ class Sync(Command):
     """
 
     OPTION_FLAGS = [
-        'delete', 'noProgress', 'skipNewer', 'replaceNewer', 'dryRun', 'allowEmptySource', 'excludeSymlinks'
+        'delete', 'noProgress', 'skipNewer', 'replaceNewer', 'dryRun', 'allowEmptySource',
+        'excludeSymlinks'
     ]
     OPTION_ARGS = ['keepDays', 'threads', 'compareVersions', 'compareThreshold']
     REQUIRED = ['source', 'destination']

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1016,6 +1016,7 @@ class Sync(Command):
             [--threads N] [--noProgress] [--dryRun ] [--allowEmptySource ] \\
             [--excludeRegex <regex> [--includeRegex <regex>]] \\
             [--excludeDirRegex <regex>] \\
+            [--excludeSymlinks ] \\
             <source> <destination>
 
         Copies multiple files from source to destination.  Optionally
@@ -1055,6 +1056,9 @@ class Sync(Command):
         of each file.
 
         Note that --includeRegex cannot be used without --excludeRegex.
+
+        You can specify --excludeSymlinks to skip symlinks when
+        syncing from a local source.
 
         When a directory is excluded by using --excludeDirRegex, all of
         the files within it are excluded, even if they match an --includeRegex
@@ -1132,7 +1136,7 @@ class Sync(Command):
     """
 
     OPTION_FLAGS = [
-        'delete', 'noProgress', 'skipNewer', 'replaceNewer', 'dryRun', 'allowEmptySource'
+        'delete', 'noProgress', 'skipNewer', 'replaceNewer', 'dryRun', 'allowEmptySource', 'excludeSymlinks'
     ]
     OPTION_ARGS = ['keepDays', 'threads', 'compareVersions', 'compareThreshold']
     REQUIRED = ['source', 'destination']
@@ -1156,6 +1160,7 @@ class Sync(Command):
             exclude_dir_regexes=args.excludeDirRegex,
             exclude_file_regexes=args.excludeRegex,
             include_file_regexes=args.includeRegex,
+            exclude_symlinks=args.excludeSymlinks,
         )
         sync_folders(
             source_folder=source,

--- a/b2/sync/folder.py
+++ b/b2/sync/folder.py
@@ -169,6 +169,10 @@ class LocalFolder(AbstractFolder):
             if not is_file_readable(local_path, reporter):
                 continue
 
+            if policies_manager.exclude_symlinks and os.path.islink(local_path):
+                reporter.local_symlink_notice(local_path)
+                continue
+
             if os.path.isdir(local_path):
                 name += six.u('/')
                 if policies_manager.should_exclude_directory(b2_path):

--- a/b2/sync/folder.py
+++ b/b2/sync/folder.py
@@ -169,8 +169,8 @@ class LocalFolder(AbstractFolder):
             if not is_file_readable(local_path, reporter):
                 continue
 
-            if policies_manager.exclude_symlinks and os.path.islink(local_path):
-                reporter.local_symlink_notice(local_path)
+            if policies_manager.exclude_all_symlinks and os.path.islink(local_path):
+                reporter.local_symlink_skip_notice(local_path)
                 continue
 
             if os.path.isdir(local_path):

--- a/b2/sync/folder.py
+++ b/b2/sync/folder.py
@@ -170,7 +170,7 @@ class LocalFolder(AbstractFolder):
                 continue
 
             if policies_manager.exclude_all_symlinks and os.path.islink(local_path):
-                reporter.local_symlink_skip_notice(local_path)
+                reporter.symlink_skipped(local_path)
                 continue
 
             if os.path.isdir(local_path):

--- a/b2/sync/report.py
+++ b/b2/sync/report.py
@@ -199,7 +199,7 @@ class SyncReport(object):
         )
 
     def symlink_skipped(self, path):
-        self.print_completion('skipped symlink %s' % (path,))
+        pass
 
 
 class SyncFileReporter(AbstractProgressListener):

--- a/b2/sync/report.py
+++ b/b2/sync/report.py
@@ -198,7 +198,7 @@ class SyncReport(object):
             'WARNING: %s could not be accessed (no permissions to read?)' % (path,)
         )
 
-    def local_symlink_skip_notice(self, path):
+    def symlink_skipped(self, path):
         self.print_completion('skipped symlink %s' % (path,))
 
 

--- a/b2/sync/report.py
+++ b/b2/sync/report.py
@@ -198,7 +198,7 @@ class SyncReport(object):
             'WARNING: %s could not be accessed (no permissions to read?)' % (path,)
         )
 
-    def local_symlink_notice(self, path):
+    def local_symlink_skip_notice(self, path):
         self.print_completion('skipped symlink %s' % (path,))
 
 

--- a/b2/sync/report.py
+++ b/b2/sync/report.py
@@ -201,6 +201,7 @@ class SyncReport(object):
     def local_symlink_notice(self, path):
         self.print_completion('skipped symlink %s' % (path,))
 
+
 class SyncFileReporter(AbstractProgressListener):
     """
     Listens to the progress for a single file and passes info on to a SyncReporter.

--- a/b2/sync/report.py
+++ b/b2/sync/report.py
@@ -198,6 +198,8 @@ class SyncReport(object):
             'WARNING: %s could not be accessed (no permissions to read?)' % (path,)
         )
 
+    def local_symlink_notice(self, path):
+        self.print_completion('skipped symlink %s' % (path,))
 
 class SyncFileReporter(AbstractProgressListener):
     """

--- a/b2/sync/scan_policies.py
+++ b/b2/sync/scan_policies.py
@@ -73,6 +73,7 @@ class ScanPoliciesManager(object):
         exclude_dir_regexes=tuple(),
         exclude_file_regexes=tuple(),
         include_file_regexes=tuple(),
+        exclude_symlinks=False,
     ):
         self._exclude_dir_set = RegexSet(exclude_dir_regexes)
         self._exclude_file_because_of_dir_set = RegexSet(
@@ -80,6 +81,7 @@ class ScanPoliciesManager(object):
         )
         self._exclude_file_set = RegexSet(exclude_file_regexes)
         self._include_file_set = RegexSet(include_file_regexes)
+        self.exclude_symlinks  = exclude_symlinks
 
     def should_exclude_file(self, file_path):
         """

--- a/b2/sync/scan_policies.py
+++ b/b2/sync/scan_policies.py
@@ -81,7 +81,7 @@ class ScanPoliciesManager(object):
         )
         self._exclude_file_set = RegexSet(exclude_file_regexes)
         self._include_file_set = RegexSet(include_file_regexes)
-        self.exclude_symlinks  = exclude_symlinks
+        self.exclude_symlinks = exclude_symlinks
 
     def should_exclude_file(self, file_path):
         """

--- a/b2/sync/scan_policies.py
+++ b/b2/sync/scan_policies.py
@@ -73,7 +73,7 @@ class ScanPoliciesManager(object):
         exclude_dir_regexes=tuple(),
         exclude_file_regexes=tuple(),
         include_file_regexes=tuple(),
-        exclude_symlinks=False,
+        exclude_all_symlinks=False,
     ):
         self._exclude_dir_set = RegexSet(exclude_dir_regexes)
         self._exclude_file_because_of_dir_set = RegexSet(
@@ -81,7 +81,7 @@ class ScanPoliciesManager(object):
         )
         self._exclude_file_set = RegexSet(exclude_file_regexes)
         self._include_file_set = RegexSet(include_file_regexes)
-        self.exclude_symlinks = exclude_symlinks
+        self.exclude_all_symlinks = exclude_all_symlinks
 
     def should_exclude_file(self, file_path):
         """

--- a/test/test_bucket.py
+++ b/test/test_bucket.py
@@ -242,8 +242,8 @@ class TestLs(TestCaseWithBucket):
         self.bucket.upload_bytes(data, 'ccc')
         expected = [
             ('9998', 'bb/1', 11, 'upload', None), ('9995', 'bb/2', 11, 'upload', None),
-            ('9996', 'bb/2', 11, 'upload', None), ('9997', 'bb/2', 11, 'upload',
-                                                   None), ('9994', 'bb/3', 11, 'upload', None)
+            ('9996', 'bb/2', 11, 'upload', None), ('9997', 'bb/2', 11, 'upload', None),
+            ('9994', 'bb/3', 11, 'upload', None)
         ]
         actual = [
             (info.id_, info.file_name, info.size, info.action, folder)

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -1064,9 +1064,8 @@ class TestConsoleTool(TestBase):
         self._create_my_bucket()
 
         with TempDir() as temp_dir:
-            file_path = os.path.join(temp_dir, 'test.txt')
-            with open(file_path, 'wb') as f:
-                f.write(six.u('hello world').encode('utf-8'))
+            self._make_local_file(temp_dir, 'test.txt')
+            os.symlink('test.txt', os.path.join(temp_dir, 'alink'))
             expected_stdout = '''
             upload test.txt
             '''
@@ -1082,9 +1081,7 @@ class TestConsoleTool(TestBase):
         self._create_my_bucket()
 
         with TempDir() as temp_dir:
-            file_path = os.path.join(temp_dir, 'test.txt')
-            with open(file_path, 'wb') as f:
-                f.write(six.u('hello world').encode('utf-8'))
+            self._make_local_file(temp_dir, 'test.txt')
             os.symlink('test.txt', os.path.join(temp_dir, 'alink'))
             expected_stdout = '''
             upload alink

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -1059,6 +1059,41 @@ class TestConsoleTool(TestBase):
             ''' % (mtime)
             self._run_command(['list_file_names', 'my-bucket'], expected_stdout, '', 0)
 
+    def test_sync_exclude_all_symlinks(self):
+        self._authorize_account()
+        self._create_my_bucket()
+
+        with TempDir() as temp_dir:
+            file_path = os.path.join(temp_dir, 'test.txt')
+            with open(file_path, 'wb') as f:
+                f.write(six.u('hello world').encode('utf-8'))
+            expected_stdout = '''
+            upload test.txt
+            '''
+
+            command = [
+                'sync', '--threads', '1', '--noProgress', '--excludeAllSymlinks', temp_dir,
+                'b2://my-bucket'
+            ]
+            self._run_command(command, expected_stdout, '', 0)
+
+    def test_sync_dont_exclude_all_symlinks(self):
+        self._authorize_account()
+        self._create_my_bucket()
+
+        with TempDir() as temp_dir:
+            file_path = os.path.join(temp_dir, 'test.txt')
+            with open(file_path, 'wb') as f:
+                f.write(six.u('hello world').encode('utf-8'))
+            os.symlink('test.txt', os.path.join(temp_dir, 'alink'))
+            expected_stdout = '''
+            upload alink
+            upload test.txt
+            '''
+
+            command = ['sync', '--threads', '1', '--noProgress', temp_dir, 'b2://my-bucket']
+            self._run_command(command, expected_stdout, '', 0)
+
     def test_ls(self):
         self._authorize_account()
         self._create_my_bucket()

--- a/test/test_raw_api.py
+++ b/test/test_raw_api.py
@@ -44,8 +44,9 @@ class TestRawAPIFilenames(TestBase):
         :param exception_message: regexp that matches the exception's detailed message
         """
         print(
-            u"Filename \"{0}\" should raise UnusableFileName(\".*{1}.*\")."
-            .format(filename, exception_message)
+            u"Filename \"{0}\" should raise UnusableFileName(\".*{1}.*\").".format(
+                filename, exception_message
+            )
         )
         with self.assertRaisesRegexp(UnusableFileName, exception_message):
             self.raw_api.check_b2_filename(filename)

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -458,8 +458,8 @@ def b2_file(name, mod_times, size=10):
     """
     versions = [
         FileVersion(
-            'id_%s_%d' % (name[0], abs(mod_time)), 'folder/' + name, abs(mod_time), 'upload'
-            if 0 < mod_time else 'hide', size
+            'id_%s_%d' % (name[0], abs(mod_time)), 'folder/' + name, abs(mod_time),
+            'upload' if 0 < mod_time else 'hide', size
         ) for mod_time in mod_times
     ]  # yapf disable
     return File(name, versions)

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -412,6 +412,7 @@ class FakeArgs(object):
         debugLogs=True,
         dryRun=False,
         allowEmptySource=False,
+        excludeAllSymlinks=False,
     ):
         self.delete = delete
         self.keepDays = keepDays
@@ -431,6 +432,7 @@ class FakeArgs(object):
         self.debugLogs = debugLogs
         self.dryRun = dryRun
         self.allowEmptySource = allowEmptySource
+        self.excludeAllSymlinks = excludeAllSymlinks
 
 
 def b2_file(name, mod_times, size=10):
@@ -496,6 +498,7 @@ class TestExclusions(TestSync):
             exclude_dir_regexes=fakeargs.excludeDirRegex,
             exclude_file_regexes=fakeargs.excludeRegex,
             include_file_regexes=fakeargs.includeRegex,
+            exclude_all_symlinks=fakeargs.excludeAllSymlinks
         )
         actions = list(
             make_folder_sync_actions(

--- a/test_b2_command_line.py
+++ b/test_b2_command_line.py
@@ -695,7 +695,8 @@ def _sync_test_using_dir(b2_tool, bucket_name, dir_):
                 '+ ' + prefix + 'c',
                 '+ ' + prefix + 'c',
                 '+ ' + prefix + 'linktarget',
-            ], file_version_summary(file_versions)
+            ],
+            file_version_summary(file_versions),
         )
 
         # confirm symlink target is uploaded (with symlink's name)
@@ -708,7 +709,8 @@ def _sync_test_using_dir(b2_tool, bucket_name, dir_):
                 '+ ' + prefix + 'c',
                 '+ ' + prefix + 'c',
                 '+ ' + prefix + 'linktarget',
-            ], file_version_summary(file_versions)
+            ],
+            file_version_summary(file_versions),
         )
 
 

--- a/test_b2_command_line.py
+++ b/test_b2_command_line.py
@@ -680,13 +680,12 @@ def _sync_test_using_dir(b2_tool, bucket_name, dir_):
             ], file_version_summary(file_versions)
         )
 
-        # confirm symlink is skipped and reported as such
+        # confirm symlink is skipped
         write_file(p('linktarget'), b'hello')
         os.symlink('linktarget', p('alink'))
 
         b2_tool.should_succeed(
             ['sync', '--noProgress', '--excludeAllSymlinks', dir_path, b2_sync_point],
-            expected_pattern="skipped symlink .*/alink"
         )
         file_versions = b2_tool.list_file_versions(bucket_name)
         should_equal(

--- a/test_b2_command_line.py
+++ b/test_b2_command_line.py
@@ -680,6 +680,37 @@ def _sync_test_using_dir(b2_tool, bucket_name, dir_):
             ], file_version_summary(file_versions)
         )
 
+        # confirm symlink is skipped and reported as such
+        write_file(p('linktarget'), b'hello')
+        os.symlink('linktarget', p('alink'))
+
+        b2_tool.should_succeed(
+            ['sync', '--noProgress', '--excludeAllSymlinks', dir_path, b2_sync_point],
+            expected_pattern="skipped symlink .*/alink"
+        )
+        file_versions = b2_tool.list_file_versions(bucket_name)
+        should_equal(
+            [
+                '+ ' + prefix + 'c',
+                '+ ' + prefix + 'c',
+                '+ ' + prefix + 'c',
+                '+ ' + prefix + 'linktarget',
+            ], file_version_summary(file_versions)
+        )
+
+        # confirm symlink target is uploaded (with symlink's name)
+        b2_tool.should_succeed(['sync', '--noProgress', dir_path, b2_sync_point])
+        file_versions = b2_tool.list_file_versions(bucket_name)
+        should_equal(
+            [
+                '+ ' + prefix + 'alink',
+                '+ ' + prefix + 'c',
+                '+ ' + prefix + 'c',
+                '+ ' + prefix + 'c',
+                '+ ' + prefix + 'linktarget',
+            ], file_version_summary(file_versions)
+        )
+
 
 def sync_down_test(b2_tool, bucket_name):
     sync_down_helper(b2_tool, bucket_name, 'sync')


### PR DESCRIPTION
Opening this for comments -- I haven't visited this codebase in a while -- feedback on this approach is welcome and encouraged.

At first I thought of moving this into the `ScanPoliciesManager` routines, but since it affects both files and directories I elected to place the check in `LocalFolder._walk_relative_paths`.

```bash
zackse@goyeto# mkdir /tmp/symlink-test
zackse@goyeto# cd /tmp/symlink-test
zackse@goyeto# echo hello > hello
zackse@goyeto# ln -s hello hellolink
zackse@goyeto# mkdir adir
zackse@goyeto# echo hello > adir/hello2
zackse@goyeto# ln -s adir adirlink
zackse@goyeto# find -ls
126882253    0 drwxr-xr-x   6 zackse   wheel         204 Sep 20 13:18 .
126882256    0 drwxr-xr-x   3 zackse   wheel         102 Sep 20 13:18 ./adir
126882257    4 -rw-r--r--   1 zackse   wheel           6 Sep 20 13:18 ./adir/hello2
126882258    0 lrwxr-xr-x   1 zackse   wheel           4 Sep 20 13:18 ./adirlink -> adir
126882254    4 -rw-r--r--   1 zackse   wheel           6 Sep 20 13:18 ./hello
126882255    0 lrwxr-xr-x   1 zackse   wheel           5 Sep 20 13:18 ./hellolink -> hello

zackse@goyeto# b2 sync --delete --excludeSymlinks /tmp/symlink-test b2://mybucket/symlink-test
skipped symlink /tmp/symlink-test/adirlink
skipped symlink /tmp/symlink-test/hellolink
upload hello
upload adir/hello2

zackse@goyeto# b2 sync --delete /tmp/symlink-test b2://mybucket/symlink-test
upload hellolink
upload adirlink/hello2

zackse@goyeto# b2 sync --delete --excludeSymlinks /tmp/symlink-test b2://mybucket/symlink-test
skipped symlink /tmp/symlink-test/adirlink
skipped symlink /tmp/symlink-test/hellolink
delete adirlink/hello2
delete hellolink
```