### PR TITLE
Build fix: Do not depend on twine in 2.6.

### DIFF
--- a/requirements-setup.txt
+++ b/requirements-setup.txt
@@ -1,3 +1,3 @@
 nose
 setuptools
-twine
+twine; python_version >= '2.7'


### PR DESCRIPTION
The push to PyPI is done in Python 3, so it's not needed.