### PR TITLE
Correctly handle 0 byte file

### DIFF
--- a/b2/transferer/abstract.py
+++ b/b2/transferer/abstract.py
@@ -48,7 +48,7 @@ class AbstractDownloader(object):
         """
         raw_range_header = response.request.headers.get('Range')  # 'bytes 0-11'
         if raw_range_header is None:
-            return Range(0, metadata.content_length - 1)
+            return Range(0, 0 metadata.content_length == 0 else metadata.content_length - 1)
         return Range.from_header(raw_range_header)
 
     @abstractmethod

--- a/b2/transferer/abstract.py
+++ b/b2/transferer/abstract.py
@@ -48,7 +48,7 @@ class AbstractDownloader(object):
         """
         raw_range_header = response.request.headers.get('Range')  # 'bytes 0-11'
         if raw_range_header is None:
-            return Range(0, 0 metadata.content_length == 0 else metadata.content_length - 1)
+            return Range(0, 0 if metadata.content_length == 0 else metadata.content_length - 1)
         return Range.from_header(raw_range_header)
 
     @abstractmethod


### PR DESCRIPTION
This line causes an error for 0 byte files as `Range` asserts that both start and end are >= 0, thus if the file is 0 byes, -1 is passed in for end, causing an exception.