### PR TITLE
app key renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ this:
 
 # Usage
 
-    b2 authorize-account [<accountIdOrKeyId>] [<applicationKey>]
+    b2 authorize-account [<applicationKeyId>] [<applicationKey>]
     b2 cancel-all-unfinished-large-files <bucketName>
     b2 cancel-large-file <fileId>
     b2 clear-account
@@ -66,10 +66,10 @@ The default file to use is: ~/.b2_account_info
 For more details on one command: b2 help <command>
 
 When authorizing with application keys, this tool requires that the key
-have the 'listBuckets' capability so that it can take the bucket names 
-you provide on the command line and translate them into bucket IDs for the 
-B2 Storage service.  Each different command may required additional 
-capabilities.  You can find the details for each command in the help for 
+have the 'listBuckets' capability so that it can take the bucket names
+you provide on the command line and translate them into bucket IDs for the
+B2 Storage service.  Each different command may required additional
+capabilities.  You can find the details for each command in the help for
 that command.
 
 ## Parallelism and the --threads parameter
@@ -103,13 +103,16 @@ Changes:
 
 * Most of the code moved to b2sdk repository and package
 * Deprecation warning added for imports of sdk classes from cli package
+* Renaming accountId for authentication to application key Id
+    Note: this means account Id is still backwards compatible,
+    only the terminology has changed.
 
 ## 1.3.8 (December 6, 2018)
 
 New features:
 
 * New `--excludeAllSymlinks` option for `sync`.
-* Faster downloading of large files using multiple threads and bigger buffers. 
+* Faster downloading of large files using multiple threads and bigger buffers.
 
 Bug fixes:
 
@@ -129,7 +132,7 @@ Bug fixes:
 
 * Better documentation for authorize-account command.
 * Fix error reporting when using application keys
-* Fix auth issues with bucket-restricted application keys. 
+* Fix auth issues with bucket-restricted application keys.
 
 ## 1.3.2 (July 28, 2018)
 
@@ -229,9 +232,9 @@ Before checking in, use the `pre-commit.sh` script to check code formatting, run
 unit tests, run integration tests etc.
 
 The integration tests need a file in your home directory called `.b2_auth`
-that contains two lines with nothing on them but your account ID and application key:
+that contains two lines with nothing on them but your application key ID and application key:
 
-     accountId
+     applicationKeyId
      applicationKey
 
 We marked the places in the code which are significantly less intuitive than others in a special way. To find them occurrences, use `git grep '*magic*'`.

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -211,15 +211,15 @@ class Command(object):
 
 class AuthorizeAccount(Command):
     """
-    b2 authorize-account [<accountIdOrKeyId>] [<applicationKey>]
+    b2 authorize-account [<applicationKeyId>] [<applicationKey>]
 
-        Prompts for Backblaze accountID and applicationKey (unless they
-        are given on the command line).
+        Prompts for Backblaze applicationKeyId and applicationKey (unless they are given
+        on the command line).
 
         You can authorize with either the master application key or
         a normal application key.
 
-        To use the master application key, provide the account ID and
+        To use the master application key, provide the application key ID and
         application key from the "B2 Cloud Storage Buckets" page on
         the web site: https://secure.backblaze.com/b2_buckets.htm
 
@@ -235,7 +235,7 @@ class AuthorizeAccount(Command):
 
     OPTION_FLAGS = ['dev', 'staging']  # undocumented
 
-    OPTIONAL = ['accountId', 'applicationKey']
+    OPTIONAL = ['applicationKeyId', 'applicationKey']
 
     FORBID_LOGGING_ARGUMENTS = True
 
@@ -251,14 +251,14 @@ class AuthorizeAccount(Command):
         url = self.api.account_info.REALM_URLS[realm]
         self._print('Using %s' % url)
 
-        if args.accountId is None:
-            args.accountId = six.moves.input('Backblaze account ID: ')
+        if args.applicationKeyId is None:
+            args.applicationKeyId = six.moves.input('Backblaze application key ID: ')
 
         if args.applicationKey is None:
             args.applicationKey = getpass.getpass('Backblaze application key: ')
 
         try:
-            self.api.authorize_account(realm, args.accountId, args.applicationKey)
+            self.api.authorize_account(realm, args.applicationKeyId, args.applicationKey)
 
             allowed = self.api.account_info.get_allowed()
             if 'listBuckets' not in allowed['capabilities']:
@@ -278,6 +278,7 @@ class AuthorizeAccount(Command):
                 )
                 self.api.account_info.clear()
                 return 1
+            self.api.authorize_account(realm, args.applicationKeyId, args.applicationKey)
             return 0
         except B2Error as e:
             logger.exception('ConsoleTool account authorization error')

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -685,7 +685,7 @@ class TestConsoleTool(TestBase):
         self._authorize_account()
         expected_stdout = '''
         {{
-            "accountAuthToken": "auth_token_0",
+            "accountAuthToken": "auth_token_1",
             "accountId": "{account_id}",
             "allowed": {{
                 "bucketId": null,
@@ -1176,7 +1176,7 @@ class TestConsoleTool(TestBase):
         self._run_command_ignore_output(['authorize-account', app_key_id, app_key])
 
         # Auth token should be in account info now
-        self.assertEqual('auth_token_1', self.account_info.get_account_auth_token())
+        self.assertEqual('auth_token_3', self.account_info.get_account_auth_token())
 
         # Assertions that the restrictions not only are saved but what they are supposed to be
         self.assertEqual(


### PR DESCRIPTION
Rename some of the variables and the console command outputs  match our new standard that account Id is now called an application key Id in the context of authorization.

 Please enter the commit message for your changes. Lines starting