### PR TITLE
Accept authorize-account arguments via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ For advanced users, a hidden option `--logConfig <filename.ini>` can be used to 
 # Release History
 ## 1.4.1 (not released yet)
 
+Changes:
+
+* When authorizing with application keys, optional application key ID and 
+  application key can be added using environment variables 
+  B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY respectively.
+
 ## 1.4.0 (April 25, 2019)
 
 Changes:

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -47,10 +47,16 @@ logger = logging.getLogger(__name__)
 
 SEPARATOR = '=' * 40
 
+# Optional Env variable to use for getting account info while authorizing
+B2_APPLICATION_KEY_ID_ENV_VAR = 'B2_APPLICATION_KEY_ID'
+B2_APPLICATION_KEY_ENV_VAR = 'B2_APPLICATION_KEY'
+
 # Strings available to use when formatting doc strings.
 DOC_STRING_DATA = dict(
     B2_ACCOUNT_INFO_ENV_VAR=B2_ACCOUNT_INFO_ENV_VAR,
-    B2_ACCOUNT_INFO_DEFAULT_FILE=B2_ACCOUNT_INFO_DEFAULT_FILE
+    B2_ACCOUNT_INFO_DEFAULT_FILE=B2_ACCOUNT_INFO_DEFAULT_FILE,
+    B2_APPLICATION_KEY_ID_ENV_VAR=B2_APPLICATION_KEY_ID_ENV_VAR,
+    B2_APPLICATION_KEY_ENV_VAR=B2_APPLICATION_KEY_ENV_VAR,
 )
 
 # Enable to get 0.* behavior in the command-line tool.
@@ -227,6 +233,10 @@ class AuthorizeAccount(Command):
         command or on the web site, provide the application key ID
         and the application key itself.
 
+        You can also optionally provide application key ID and application key
+        using environment variables {B2_APPLICATION_KEY_ID_ENV_VAR} and
+        {B2_APPLICATION_KEY_ENV_VAR} respectively.
+
         Stores an account auth token in {B2_ACCOUNT_INFO_DEFAULT_FILE} by default,
         or the file specified by the {B2_ACCOUNT_INFO_ENV_VAR} environment variable.
 
@@ -252,10 +262,16 @@ class AuthorizeAccount(Command):
         self._print('Using %s' % url)
 
         if args.applicationKeyId is None:
-            args.applicationKeyId = six.moves.input('Backblaze application key ID: ')
+            args.applicationKeyId = (
+                os.environ.get(B2_APPLICATION_KEY_ID_ENV_VAR) or
+                six.moves.input('Backblaze application key ID: ')
+            )
 
         if args.applicationKey is None:
-            args.applicationKey = getpass.getpass('Backblaze application key: ')
+            args.applicationKey = (
+                os.environ.get(B2_APPLICATION_KEY_ENV_VAR) or
+                getpass.getpass('Backblaze application key: ')
+            )
 
         try:
             self.api.authorize_account(realm, args.applicationKeyId, args.applicationKey)

--- a/test/test_console_tool.py
+++ b/test/test_console_tool.py
@@ -16,7 +16,7 @@ from .stub_account_info import StubAccountInfo
 from .test_base import TestBase
 from b2sdk.api import B2Api
 from b2sdk.cache import InMemoryCache
-from b2.console_tool import ConsoleTool
+from b2.console_tool import ConsoleTool, B2_APPLICATION_KEY_ID_ENV_VAR, B2_APPLICATION_KEY_ENV_VAR
 from b2sdk.raw_api import API_VERSION
 from b2sdk.raw_simulator import RawSimulator
 from b2sdk.upload_source import UploadSourceBytes
@@ -79,6 +79,30 @@ class TestConsoleTool(TestBase):
         self._run_command(
             ['authorize-account', self.account_id, self.master_key], expected_stdout, '', 0
         )
+
+        # Auth token should be in account info now
+        assert self.account_info.get_account_auth_token() is not None
+
+    def test_authorize_using_env_variables(self):
+        # Initial condition
+        assert self.account_info.get_account_auth_token() is None
+
+        # Authorize an account with a good api key.
+        expected_stdout = """
+        Using http://production.example.com
+        """
+
+        # Setting up environment variables
+        with mock.patch.dict(
+            'os.environ', {
+                B2_APPLICATION_KEY_ID_ENV_VAR: self.account_id,
+                B2_APPLICATION_KEY_ENV_VAR: self.master_key,
+            }
+        ):
+            assert B2_APPLICATION_KEY_ID_ENV_VAR in os.environ
+            assert B2_APPLICATION_KEY_ENV_VAR in os.environ
+
+            self._run_command(['authorize-account'], expected_stdout, '', 0)
 
         # Auth token should be in account info now
         assert self.account_info.get_account_auth_token() is not None


### PR DESCRIPTION
User can now also optionally provide application key ID and application key using environment variables B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY respectively.