### PR TITLE
Implement make-friendly-url (Issue #577)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ this:
     b2 list-parts <largeFileId>
     b2 list-unfinished-large-files <bucketName>
     b2 ls [--long] [--versions] [--recursive] <bucketName> [<folderName>]
+    b2 make-friendly-url <bucketName> <fileName>
     b2 make-url <fileId>
     b2 sync [--delete] [--keepDays N] [--skipNewer] [--replaceNewer] \
         [--compareVersions <option>] [--compareThreshold N] \

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1141,6 +1141,21 @@ class MakeUrl(Command):
         return 0
 
 
+class MakeFriendlyUrl(Command):
+    """
+    b2 make-friendly-url <bucketName> <fileName>
+
+        Prints a short URL that can be used to download the given file, if
+        it is public.
+    """
+
+    REQUIRED = ['bucketName', 'fileName']
+
+    def run(self, args):
+        self._print(self.api.get_download_url_for_file_name(args.bucketName, args.fileName))
+        return 0
+
+
 class Sync(Command):
     """
     b2 sync [--delete] [--keepDays N] [--skipNewer] [--replaceNewer] \\


### PR DESCRIPTION
Adds a make-friendly-url command that generates a shorter, friendlier URL for sharing by passing a bucket name and filename.

`b2 make-friendly-url <bucketName> <fileName>`