### PR TITLE
Fix timeouts in tests on Travis Mac OS

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,4 @@ SPLIT_PENALTY_AFTER_OPENING_BRACKET=0
 verbosity=2
 where=test
 processes=-1
+process-timeout=60


### PR DESCRIPTION
MacOS seems to be very slow sometimes on TravisCI.