### PR TITLE
Fallback to ascii decoder in case locales are not properly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fallback to `ascii` decoder when printing help in case the locales are not properly set
+
 ## [3.1.0] - 2021-11-02
 
 ### Added

--- a/b2/arg_parser.py
+++ b/b2/arg_parser.py
@@ -9,7 +9,9 @@
 ######################################################################
 
 import argparse
+import locale
 import re
+import sys
 import textwrap
 
 import arrow
@@ -68,7 +70,8 @@ class ArgumentParser(argparse.ArgumentParser):
             if self._for_docs:
                 self._description = textwrap.dedent(self._raw_description)
             else:
-                self._description = rst2ansi(self._raw_description.encode('utf-8'))
+                encoding = self._get_encoding()
+                self._description = rst2ansi(self._raw_description.encode(encoding), output_encoding=encoding)
 
         return self._description
 
@@ -78,8 +81,18 @@ class ArgumentParser(argparse.ArgumentParser):
 
     def error(self, message):
         self.print_help()
+
         args = {'prog': self.prog, 'message': message}
         self.exit(2, '\n%(prog)s: error: %(message)s\n' % args)
+
+    @classmethod
+    def _get_encoding(cls):
+        _, locale_encoding = locale.getdefaultlocale()
+        if locale_encoding is not None:
+            return sys.getdefaultencoding()
+
+        # locales are improperly configured
+        return 'ascii'
 
 
 def parse_comma_separated_list(s):

--- a/b2/arg_parser.py
+++ b/b2/arg_parser.py
@@ -71,7 +71,9 @@ class ArgumentParser(argparse.ArgumentParser):
                 self._description = textwrap.dedent(self._raw_description)
             else:
                 encoding = self._get_encoding()
-                self._description = rst2ansi(self._raw_description.encode(encoding), output_encoding=encoding)
+                self._description = rst2ansi(
+                    self._raw_description.encode(encoding), output_encoding=encoding
+                )
 
         return self._description
 


### PR DESCRIPTION
- Fallback to ascii decoder in case locales are not properly set
- Update the changelog
- Format the code

Fixes #755
Fixes #766 