### PR TITLE
Allow for arrow >= 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Add compatibility support for arrow >= 1.0.2 on newer Python versions while
+  continuing to support Python 3.5
+
 ### Fixed
 * Fallback to `ascii` decoder when printing help in case the locales are not properly set
 

--- a/b2/arg_parser.py
+++ b/b2/arg_parser.py
@@ -18,6 +18,8 @@ import arrow
 from rst2ansi import rst2ansi
 from b2sdk.v1 import RetentionPeriod
 
+_arrow_version = tuple(int(p) for p in arrow.__version__.split("."))
+
 
 class RawTextHelpFormatter(argparse.RawTextHelpFormatter):
     """
@@ -101,14 +103,18 @@ def parse_comma_separated_list(s):
     """
     Parse comma-separated list.
     """
-    return [word.strip() for word in s.split(',')]
+    return [word.strip() for word in s.split(",")]
 
 
 def parse_millis_from_float_timestamp(s):
     """
     Parse timestamp, e.g. 1367900664 or 1367900664.152
     """
-    return int(arrow.get(float(s)).format('XSSS'))
+    parsed = arrow.get(float(s))
+    if _arrow_version < (1, 0, 0):
+        return int(parsed.format("XSSS"))
+    else:
+        return int(parsed.format("x")[:13])
 
 
 def parse_range(s):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-arrow>=0.8.0,<1.0.0
+arrow>=0.8.0,<1.0.0; python_version <= '3.5'
+arrow>=1.0.2,<2.0.0; python_version >= '3.6'
 b2sdk>=1.13.0,<2.0.0
 docutils==0.16
 idna>=2.2.0; platform_system == 'Java'


### PR DESCRIPTION
Add some code that allows for arrow > 1.0 so that we can stop
restricting this for users relying on distribution packages. This code
handles the divergent behaviour of arrow on the 1.x and 0.x branches.

Related-to https://github.com/Backblaze/b2-sdk-python/issues/201
Unblocks https://github.com/Backblaze/b2-sdk-python/pull/204
Closes https://github.com/Backblaze/B2_Command_Line_Tool/issues/687