### PR TITLE
Replication monitoring: update tests to use new source_encryption_mode field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-* Add `replication-status` command
 * Add `replication-delete` command
 * Add `replication-pause` command
+* Add `replication-status` command
 * Add `replication-unpause` command
 * Add `--include-existing-files` to `replication-setup`
 

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -2111,7 +2111,6 @@ def test_replication_setup(b2_api, b2_tool, bucket_name):
             'asReplicationDestination']['sourceToDestinationKeyMapping']
 
 
-@pytest.mark.xfail(reason="Fails because of changes introduced in the SDK")
 def test_replication_monitoring(b2_tool, bucket_name, b2_api):
 
     # ---------------- set up keys ----------------
@@ -2288,7 +2287,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                         "source_has_hide_marker": None,
                         "source_has_large_metadata": None,
                         "source_has_legal_hold": None,
-                        "source_has_sse_c_enabled": None,
+                        "source_encryption_mode": None,
                         "source_replication_status": None,
                     }
                 ],
@@ -2303,7 +2302,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                         "source_has_hide_marker": False,
                         "source_has_large_metadata": False,
                         "source_has_legal_hold": True,
-                        "source_has_sse_c_enabled": False,
+                        "source_encryption_mode": 'none',
                         "source_replication_status": first,
                     }, {
                         "count": 1,
@@ -2314,7 +2313,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                         "source_has_hide_marker": False,
                         "source_has_large_metadata": False,
                         "source_has_legal_hold": False,
-                        "source_has_sse_c_enabled": False,
+                        "source_encryption_mode": 'SSE-B2',
                         "source_replication_status": second,
                     }, {
                         "count": 1,
@@ -2325,7 +2324,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                         "source_has_hide_marker": False,
                         "source_has_large_metadata": False,
                         "source_has_legal_hold": False,
-                        "source_has_sse_c_enabled": True,
+                        "source_encryption_mode": 'SSE-C',
                         "source_replication_status": None,
                     }, {
                         "count": 1,
@@ -2336,7 +2335,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                         "source_has_hide_marker": False,
                         "source_has_large_metadata": False,
                         "source_has_legal_hold": True,
-                        "source_has_sse_c_enabled": True,
+                        "source_encryption_mode": 'SSE-C',
                         "source_replication_status": None,
                     }
                 ]


### PR DESCRIPTION
Displaying the "source_encryption_mode" field in replication monitoring does not need any changes, the b2 sdk change is picked up automatically. Tests need to be adjusted however, and this PR fixes it.