### PR TITLE
Fix tests failing due to new versions of dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fix `replication-setup` default priority setter
 
+### Infrastructure
+* Fix tests failing due to new versions of dependencies
+
 ## [3.5.0] - 2022-07-27
 
 As in 3.4.0, replication support may be unstable, however no backward-incompatible


### PR DESCRIPTION
```
============================================================= warnings summary =============================================================
b2/console_tool.py:1811
    /Users/alotfulina/repos/B2_Command_Line_Tool/b2/console_tool.py:1811: DeprecationWarning: invalid escape sequence '\.'
        """

.nox/integration-3-10/lib/python3.10/site-packages/rst2ansi/visitor.py:27
    /Users/alotfulina/repos/B2_Command_Line_Tool/.nox/integration-3-10/lib/python3.10/site-packages/rst2ansi/visitor.py:27: DeprecationWarning: The `docutils.utils.error_reporting` module is deprecated and will be removed in Docutils 0.21 or later.
    Details with help("docutils.utils.error_reporting").
        from docutils.utils.error_reporting import SafeString

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================ 27 passed, 2 warnings in 134.63s (0:02:14) ================================================
nox > Session integration-3.10 was successful.
```