### PR TITLE
Fix bucket leaks in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 env:
   PYTHON_DEFAULT_VERSION: "3.10"
 
+concurrency: continuous-integration
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/noxfile.py
+++ b/noxfile.py
@@ -158,10 +158,9 @@ def integration(session):
     """Run integration tests."""
     install_myself(session)
     session.run('pip', 'install', *REQUIREMENTS_TEST)
-    #session.run('pytest', '-s', '-x', '-v', '-n', '4', *session.posargs, 'test/integration')
     session.run(
-        'pytest', '-s', '-x', '-v', '-W', 'ignore::DeprecationWarning:rst2ansi.visitor:',
-        *session.posargs, 'test/integration'
+        'pytest', '-s', '-x', '-v', '-n', 'auto', '-W',
+        'ignore::DeprecationWarning:rst2ansi.visitor:', *session.posargs, 'test/integration'
     )
 
 

--- a/test/integration/cleanup_buckets.py
+++ b/test/integration/cleanup_buckets.py
@@ -13,4 +13,4 @@ def test_cleanup_buckets(b2_api):
     # this is not a test, but it is intended to be called
     # via pytest because it reuses fixtures which have everything
     # set up
-    b2_api.clean_buckets()
+    b2_api.clean_all_buckets()

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -19,9 +19,7 @@ import pytest
 from b2sdk.v2 import B2_ACCOUNT_INFO_ENV_VAR, XDG_CONFIG_HOME_ENV_VAR
 from b2sdk.exception import BucketIdNotFound
 
-from .helpers import Api, CommandLine, bucket_name_part
-
-GENERAL_BUCKET_NAME_PREFIX = 'clitst'
+from .helpers import Api, CommandLine
 
 
 @pytest.hookimpl
@@ -52,32 +50,16 @@ def realm() -> str:
 
 
 @pytest.fixture(scope='function')
-def bucket_name(b2_api) -> str:
-    bucket = b2_api.create_bucket()
-    yield bucket.name
-    with contextlib.suppress(BucketIdNotFound):
-        b2_api.clean_bucket(bucket)
+def create_test_bucket(b2_api):
+    def factory(*args, **kwargs):
+        return b2_api.create_test_bucket(*args, **kwargs).name
+
+    return factory
 
 
-@pytest.fixture(scope='function')  # , autouse=True)
-def debug_print_buckets(b2_api):
-    print('-' * 30)
-    print('Buckets before test ' + environ['PYTEST_CURRENT_TEST'])
-    num_buckets = b2_api.count_and_print_buckets()
-    print('-' * 30)
-    try:
-        yield
-    finally:
-        print('-' * 30)
-        print('Buckets after test ' + environ['PYTEST_CURRENT_TEST'])
-        delta = b2_api.count_and_print_buckets() - num_buckets
-        print(f'DELTA: {delta}')
-        print('-' * 30)
-
-
-@pytest.fixture(scope='session')
-def this_run_bucket_name_prefix() -> str:
-    yield GENERAL_BUCKET_NAME_PREFIX + bucket_name_part(8)
+@pytest.fixture(scope='function')
+def bucket_name(create_test_bucket) -> str:
+    return create_test_bucket()
 
 
 @pytest.fixture(scope='module')
@@ -108,23 +90,14 @@ def auto_change_account_info_dir(monkey_patch) -> dir:
 
 
 @pytest.fixture(scope='module')
-def b2_api(application_key_id, application_key, realm, this_run_bucket_name_prefix) -> Api:
-    yield Api(
-        application_key_id, application_key, realm, GENERAL_BUCKET_NAME_PREFIX,
-        this_run_bucket_name_prefix
-    )
+def b2_api(application_key_id, application_key, realm) -> Api:
+    return Api(application_key_id, application_key, realm)
 
 
 @pytest.fixture(scope='module')
-def b2_tool(
-    request, application_key_id, application_key, realm, this_run_bucket_name_prefix
-) -> CommandLine:
+def b2_tool(request, application_key_id, application_key, realm) -> CommandLine:
     tool = CommandLine(
-        request.config.getoption('--sut'),
-        application_key_id,
-        application_key,
-        realm,
-        this_run_bucket_name_prefix,
+        request.config.getoption('--sut'), application_key_id, application_key, realm
     )
     tool.reauthorize(check_key_capabilities=True)  # reauthorize for the first time (with check)
     return tool
@@ -134,3 +107,19 @@ def b2_tool(
 def auto_reauthorize(request, b2_tool):
     """ Automatically reauthorize for each test (without check) """
     b2_tool.reauthorize(check_key_capabilities=False)
+
+
+@pytest.fixture(scope='function', autouse=True)
+def auto_clean_buckets(b2_api, b2_tool):
+    """Automatically delete created buckets after each test case"""
+    yield
+
+    # remove buckets created using the CLI
+    while b2_tool.buckets:
+        with contextlib.suppress(BucketIdNotFound):
+            # The buckets were created with the CLI tool, but we still delete them using the API as it will handle
+            # corner cases properly (like retries or deleting non-empty buckets).
+            b2_api.clean_bucket(b2_tool.buckets.pop())
+
+    # remove buckets created using the API
+    b2_api.clean_buckets()

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -18,17 +18,13 @@ import os.path
 import re
 
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 from b2sdk.v2 import B2_ACCOUNT_INFO_ENV_VAR, SSE_C_KEY_ID_FILE_INFO_KEY_NAME, UNKNOWN_FILE_RETENTION_SETTING, EncryptionMode, EncryptionSetting, FileRetentionSetting, LegalHold, RetentionMode, fix_windows_path_limit
 
 from b2.console_tool import current_time_millis
 
-from .helpers import BUCKET_CREATED_AT_MILLIS, ONE_DAY_MILLIS, ONE_HOUR_MILLIS, SSE_B2_AES, SSE_C_AES, SSE_C_AES_2, SSE_NONE, TempDir, file_mod_time_millis, random_hex, read_file, set_file_mod_time_millis, should_equal, write_file
-
-
-def get_bucketinfo() -> Tuple[str, str]:
-    return '--bucketInfo', json.dumps({BUCKET_CREATED_AT_MILLIS: str(current_time_millis())}),
+from .helpers import ONE_DAY_MILLIS, ONE_HOUR_MILLIS, SSE_B2_AES, SSE_C_AES, SSE_C_AES_2, SSE_NONE, TempDir, file_mod_time_millis, generate_bucket_name, random_hex, read_file, set_file_mod_time_millis, should_equal, write_file
 
 
 def test_download(b2_tool, bucket_name):
@@ -158,15 +154,12 @@ def test_basic(b2_tool, bucket_name):
             file_to_upload,
         ),
     )  # \r? is for Windows, as $ doesn't match \r\n
-    to_be_removed_bucket_name = b2_tool.generate_bucket_name()
-    b2_tool.should_succeed(
-        [
-            'create-bucket',
-            to_be_removed_bucket_name,
-            'allPublic',
-            *get_bucketinfo(),
-        ],
-    )
+    to_be_removed_bucket_name = generate_bucket_name()
+    b2_tool.should_succeed([
+        'create-bucket',
+        to_be_removed_bucket_name,
+        'allPublic',
+    ],)
     b2_tool.should_succeed(['delete-bucket', to_be_removed_bucket_name],)
     b2_tool.should_fail(
         ['delete-bucket', to_be_removed_bucket_name],
@@ -214,7 +207,7 @@ def test_bucket(b2_tool, bucket_name):
         "fileNamePrefix": ""
     }]"""
     output = b2_tool.should_succeed_json(
-        ['update-bucket', '--lifecycleRules', rules, bucket_name, 'allPublic', *get_bucketinfo()],
+        ['update-bucket', '--lifecycleRules', rules, bucket_name, 'allPublic'],
     )
     assert output["lifecycleRules"] == [
         {
@@ -225,10 +218,9 @@ def test_bucket(b2_tool, bucket_name):
     ]
 
 
-def test_key_restrictions(b2_api, b2_tool, bucket_name):
-
-    second_bucket_name = b2_tool.generate_bucket_name()
-    b2_tool.should_succeed(['create-bucket', second_bucket_name, 'allPublic', *get_bucketinfo()],)
+def test_key_restrictions(b2_tool, create_test_bucket):
+    first_bucket_name = create_test_bucket()
+    second_bucket_name = create_test_bucket()
 
     key_one_name = 'clt-testKey-01' + random_hex(6)
     created_key_stdout = b2_tool.should_succeed(
@@ -244,7 +236,7 @@ def test_key_restrictions(b2_api, b2_tool, bucket_name):
         ['authorize-account', '--environment', b2_tool.realm, key_one_id, key_one],
     )
 
-    b2_tool.should_succeed(['get-bucket', bucket_name],)
+    b2_tool.should_succeed(['get-bucket', first_bucket_name],)
     b2_tool.should_succeed(['get-bucket', second_bucket_name],)
 
     key_two_name = 'clt-testKey-02' + random_hex(6)
@@ -252,7 +244,7 @@ def test_key_restrictions(b2_api, b2_tool, bucket_name):
         [
             'create-key',
             '--bucket',
-            bucket_name,
+            first_bucket_name,
             key_two_name,
             'listFiles,listBuckets,readFiles',
         ]
@@ -262,13 +254,13 @@ def test_key_restrictions(b2_api, b2_tool, bucket_name):
     b2_tool.should_succeed(
         ['authorize-account', '--environment', b2_tool.realm, key_two_id, key_two],
     )
-    b2_tool.should_succeed(['get-bucket', bucket_name],)
-    b2_tool.should_succeed(['ls', bucket_name],)
+    b2_tool.should_succeed(['get-bucket', first_bucket_name],)
+    b2_tool.should_succeed(['ls', first_bucket_name],)
 
-    failed_bucket_err = r'ERROR: Application key is restricted to bucket: ' + bucket_name
+    failed_bucket_err = r'ERROR: Application key is restricted to bucket: ' + first_bucket_name
     b2_tool.should_fail(['get-bucket', second_bucket_name], failed_bucket_err)
 
-    failed_list_files_err = r'ERROR: Application key is restricted to bucket: ' + bucket_name
+    failed_list_files_err = r'ERROR: Application key is restricted to bucket: ' + first_bucket_name
     b2_tool.should_fail(['ls', second_bucket_name], failed_list_files_err)
 
     # reauthorize with more capabilities for clean up
@@ -278,17 +270,17 @@ def test_key_restrictions(b2_api, b2_tool, bucket_name):
             b2_tool.application_key
         ]
     )
-    b2_api.clean_bucket(second_bucket_name)
     b2_tool.should_succeed(['delete-key', key_one_id])
     b2_tool.should_succeed(['delete-key', key_two_id])
 
 
-def test_account(b2_tool, bucket_name):
+def test_account(b2_tool, create_test_bucket):
     # actually a high level operations test - we run bucket tests here since this test doesn't use it
+    bucket_name = create_test_bucket()
     b2_tool.should_succeed(['delete-bucket', bucket_name])
-    new_bucket_name = b2_tool.generate_bucket_name()
+    new_bucket_name = generate_bucket_name()
     # apparently server behaves erratically when we delete a bucket and recreate it right away
-    b2_tool.should_succeed(['create-bucket', new_bucket_name, 'allPrivate', *get_bucketinfo()])
+    b2_tool.should_succeed(['create-bucket', new_bucket_name, 'allPrivate'])
     b2_tool.should_succeed(['update-bucket', new_bucket_name, 'allPublic'])
     b2_tool.should_succeed(['delete-bucket', new_bucket_name])
 
@@ -314,7 +306,7 @@ def test_account(b2_tool, bucket_name):
 
         # first, let's make sure "create-bucket" doesn't work without auth data - i.e. that the sqlite file hs been
         # successfully removed
-        bucket_name = b2_tool.generate_bucket_name()
+        bucket_name = generate_bucket_name()
         b2_tool.should_fail(
             ['create-bucket', bucket_name, 'allPrivate'],
             r'ERROR: Missing account data: \'NoneType\' object is not subscriptable (\(key 0\) )? '
@@ -328,8 +320,8 @@ def test_account(b2_tool, bucket_name):
         os.environ['B2_APPLICATION_KEY_ID'] = os.environ['B2_TEST_APPLICATION_KEY_ID']
         os.environ['B2_ENVIRONMENT'] = b2_tool.realm
 
-        bucket_name = b2_tool.generate_bucket_name()
-        b2_tool.should_succeed(['create-bucket', bucket_name, 'allPrivate', *get_bucketinfo()])
+        bucket_name = generate_bucket_name()
+        b2_tool.should_succeed(['create-bucket', bucket_name, 'allPrivate'])
         b2_tool.should_succeed(['delete-bucket', bucket_name])
         assert os.path.exists(new_creds), 'sqlite file not created'
 
@@ -770,43 +762,40 @@ def sync_down_helper(b2_tool, bucket_name, folder_in_bucket, encryption=None):
             )
 
 
-def test_sync_copy(b2_api, b2_tool, bucket_name):
-    prepare_and_run_sync_copy_tests(b2_api, b2_tool, bucket_name, 'sync')
+def test_sync_copy(b2_tool, create_test_bucket):
+    prepare_and_run_sync_copy_tests(b2_tool, create_test_bucket, 'sync')
 
 
-def test_sync_copy_no_prefix_default_encryption(b2_api, b2_tool, bucket_name):
+def test_sync_copy_no_prefix_default_encryption(b2_tool, create_test_bucket):
     prepare_and_run_sync_copy_tests(
-        b2_api, b2_tool, bucket_name, '', destination_encryption=None, expected_encryption=SSE_NONE
+        b2_tool, create_test_bucket, '', destination_encryption=None, expected_encryption=SSE_NONE
     )
 
 
-def test_sync_copy_no_prefix_no_encryption(b2_api, b2_tool, bucket_name):
+def test_sync_copy_no_prefix_no_encryption(b2_tool, create_test_bucket):
     prepare_and_run_sync_copy_tests(
-        b2_api,
         b2_tool,
-        bucket_name,
+        create_test_bucket,
         '',
         destination_encryption=SSE_NONE,
         expected_encryption=SSE_NONE
     )
 
 
-def test_sync_copy_no_prefix_sse_b2(b2_api, b2_tool, bucket_name):
+def test_sync_copy_no_prefix_sse_b2(b2_tool, create_test_bucket):
     prepare_and_run_sync_copy_tests(
-        b2_api,
         b2_tool,
-        bucket_name,
+        create_test_bucket,
         '',
         destination_encryption=SSE_B2_AES,
         expected_encryption=SSE_B2_AES,
     )
 
 
-def test_sync_copy_no_prefix_sse_c(b2_api, b2_tool, bucket_name):
+def test_sync_copy_no_prefix_sse_c(b2_tool, create_test_bucket):
     prepare_and_run_sync_copy_tests(
-        b2_api,
         b2_tool,
-        bucket_name,
+        create_test_bucket,
         '',
         destination_encryption=SSE_C_AES,
         expected_encryption=SSE_C_AES,
@@ -846,25 +835,22 @@ def test_sync_copy_sse_c_single_bucket(b2_tool, bucket_name):
 
 
 def prepare_and_run_sync_copy_tests(
-    b2_api,
     b2_tool,
-    bucket_name,
+    create_test_bucket,
     folder_in_bucket,
     destination_encryption=None,
     expected_encryption=SSE_NONE,
     source_encryption=None,
 ):
+    bucket_name = create_test_bucket()
+    other_bucket_name = create_test_bucket()
+
     b2_sync_point = 'b2:%s' % bucket_name
     if folder_in_bucket:
         b2_sync_point += '/' + folder_in_bucket
         b2_file_prefix = folder_in_bucket + '/'
     else:
         b2_file_prefix = ''
-
-    other_bucket_name = b2_tool.generate_bucket_name()
-    success, _ = b2_tool.run_command(
-        ['create-bucket', other_bucket_name, 'allPublic', *get_bucketinfo()]
-    )
 
     other_b2_sync_point = 'b2:%s' % other_bucket_name
     if folder_in_bucket:
@@ -898,8 +884,6 @@ def prepare_and_run_sync_copy_tests(
         ],
         file_version_summary_with_encryption(file_versions),
     )
-
-    b2_api.clean_bucket(other_bucket_name)
 
 
 def run_sync_copy_with_basic_checks(
@@ -1018,7 +1002,7 @@ def test_sync_long_path(b2_tool, bucket_name):
         should_equal(['+ ' + long_path], file_version_summary(file_versions))
 
 
-def test_default_sse_b2(b2_api, b2_tool, bucket_name):
+def test_default_sse_b2(b2_tool, bucket_name):
     # Set default encryption via update-bucket
     bucket_info = b2_tool.should_succeed_json(['get-bucket', bucket_name])
     bucket_default_sse = {'mode': 'none'}
@@ -1041,14 +1025,13 @@ def test_default_sse_b2(b2_api, b2_tool, bucket_name):
     should_equal(bucket_default_sse, bucket_info['defaultServerSideEncryption'])
 
     # Set default encryption via create-bucket
-    second_bucket_name = b2_tool.generate_bucket_name()
+    second_bucket_name = generate_bucket_name()
     b2_tool.should_succeed(
         [
             'create-bucket',
             '--defaultServerSideEncryption=SSE-B2',
             second_bucket_name,
             'allPublic',
-            *get_bucketinfo(),
         ]
     )
     second_bucket_info = b2_tool.should_succeed_json(['get-bucket', second_bucket_name])
@@ -1057,7 +1040,6 @@ def test_default_sse_b2(b2_api, b2_tool, bucket_name):
         'mode': 'SSE-B2',
     }
     should_equal(second_bucket_default_sse, second_bucket_info['defaultServerSideEncryption'])
-    b2_api.clean_bucket(second_bucket_name)
 
 
 def test_sse_b2(b2_tool, bucket_name):
@@ -1426,16 +1408,8 @@ def test_sse_c(b2_tool, bucket_name):
     )
 
 
-def test_file_lock(b2_tool, application_key_id, application_key, b2_api):
-    lock_disabled_bucket_name = b2_tool.generate_bucket_name()
-    b2_tool.should_succeed(
-        [
-            'create-bucket',
-            lock_disabled_bucket_name,
-            'allPrivate',
-            *get_bucketinfo(),
-        ],
-    )
+def test_file_lock(b2_tool, create_test_bucket):
+    lock_disabled_bucket_name = create_test_bucket("allPrivate")
 
     file_to_upload = 'README.md'
     now_millis = current_time_millis()
@@ -1480,14 +1454,13 @@ def test_file_lock(b2_tool, application_key_id, application_key, b2_api):
             'compliance', '--defaultRetentionPeriod', '7 days'
         ], r'ERROR: The bucket is not file lock enabled \(bucket_missing_file_lock\)'
     )
-    lock_enabled_bucket_name = b2_tool.generate_bucket_name()
+    lock_enabled_bucket_name = generate_bucket_name()
     b2_tool.should_succeed(
         [
             'create-bucket',
             lock_enabled_bucket_name,
             'allPrivate',
             '--fileLockEnabled',
-            *get_bucketinfo(),
         ],
     )
     updated_bucket = b2_tool.should_succeed_json(
@@ -1697,18 +1670,6 @@ def test_file_lock(b2_tool, application_key_id, application_key, b2_api):
         not_lockable_file['fileId']
     )
 
-    # ---- perform test cleanup ----
-    b2_tool.should_succeed(
-        ['authorize-account', '--environment', b2_tool.realm, application_key_id, application_key],
-    )
-    # b2_tool.reauthorize(check_key_capabilities=False)
-    buckets = [
-        bucket for bucket in b2_api.api.list_buckets()
-        if bucket.name in {lock_enabled_bucket_name, lock_disabled_bucket_name}
-    ]
-    for bucket in buckets:
-        b2_api.clean_bucket(bucket)
-
 
 def file_lock_without_perms_test(
     b2_tool, lock_enabled_bucket_name, lock_disabled_bucket_name, lockable_file_id,
@@ -1903,7 +1864,7 @@ def test_profile_switch(b2_tool):
         os.environ[B2_ACCOUNT_INFO_ENV_VAR] = B2_ACCOUNT_INFO
 
 
-def test_replication_basic(b2_api, b2_tool, bucket_name):
+def test_replication_basic(b2_tool, bucket_name):
     key_one_name = 'clt-testKey-01' + random_hex(6)
     created_key_stdout = b2_tool.should_succeed(
         [
@@ -1986,7 +1947,7 @@ def test_replication_basic(b2_api, b2_tool, bucket_name):
     source_replication_configuration_json = json.dumps(source_replication_configuration)
 
     # create a source bucket and set up replication to destination bucket
-    source_bucket_name = b2_tool.generate_bucket_name()
+    source_bucket_name = generate_bucket_name()
     b2_tool.should_succeed(
         [
             'create-bucket',
@@ -1995,7 +1956,6 @@ def test_replication_basic(b2_api, b2_tool, bucket_name):
             '--fileLockEnabled',
             '--replication',
             source_replication_configuration_json,
-            *get_bucketinfo(),
         ]
     )
     source_bucket = b2_tool.should_succeed_json(['get-bucket', source_bucket_name])
@@ -2047,21 +2007,12 @@ def test_replication_basic(b2_api, b2_tool, bucket_name):
 
     b2_tool.should_succeed(['delete-key', key_one_id])
     b2_tool.should_succeed(['delete-key', key_two_id])
-    b2_api.clean_bucket(source_bucket_name)
 
 
-def test_replication_setup(b2_api, b2_tool, bucket_name):
-    source_bucket_name = b2_tool.generate_bucket_name()
-    b2_tool.should_succeed(
-        [
-            'create-bucket',
-            source_bucket_name,
-            'allPublic',
-            '--fileLockEnabled',
-            *get_bucketinfo(),
-        ]
-    )
-    destination_bucket_name = bucket_name
+def test_replication_setup(b2_tool, create_test_bucket):
+    destination_bucket_name = create_test_bucket()
+    source_bucket_name = create_test_bucket(is_file_lock_enabled=True)
+
     b2_tool.should_succeed(['replication-setup', source_bucket_name, destination_bucket_name])
     destination_bucket_old = b2_tool.should_succeed_json(['get-bucket', destination_bucket_name])
 
@@ -2103,13 +2054,12 @@ def test_replication_setup(b2_api, b2_tool, bucket_name):
         'sourceToDestinationKeyMapping'].items():
         b2_tool.should_succeed(['delete-key', key_one_id])
         b2_tool.should_succeed(['delete-key', key_two_id])
-    b2_api.clean_bucket(source_bucket_name)
     assert destination_bucket_old['replication']['asReplicationDestination'][
         'sourceToDestinationKeyMapping'] == destination_bucket['replication'][
             'asReplicationDestination']['sourceToDestinationKeyMapping']
 
 
-def test_replication_monitoring(b2_tool, bucket_name, b2_api):
+def test_replication_monitoring(b2_tool, bucket_name):
 
     # ---------------- set up keys ----------------
     key_one_name = 'clt-testKey-01' + random_hex(6)
@@ -2188,7 +2138,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
     source_replication_configuration_json = json.dumps(source_replication_configuration)
 
     # create a source bucket and set up replication to destination bucket
-    source_bucket_name = b2_tool.generate_bucket_name()
+    source_bucket_name = generate_bucket_name()
     b2_tool.should_succeed(
         [
             'create-bucket',
@@ -2197,7 +2147,6 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
             '--fileLockEnabled',
             '--replication',
             source_replication_configuration_json,
-            *get_bucketinfo(),
         ]
     )
 
@@ -2339,8 +2288,6 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                 ]
         } for first, second in itertools.product(['FAILED', 'PENDING'], ['FAILED', 'PENDING'])
     ]
-
-    b2_api.clean_bucket(source_bucket_name)
 
 
 def _assert_file_lock_configuration(


### PR DESCRIPTION
This PR fixes bucket clean ups during integration test teardown.  This is achieved by tracking created and deleted buckets (both via the API and the CLI) and deleting everything which might have not been deleted automatically after each test case.

Additionally, a `create_test_bucket` fixture factory has been introduced, which allows for easy bucket creation.  This is useful especially in tests, which need to create more than one bucket.  The `bucket_name` fixture is still available and in use in simpler test cases.

Some buckets are still created using the `create-bucket` CLI command -- this was left this way on purpose, to ensure the command and its switches are covered by tests too.

The PR also re-enables parallel integration test execution (`pytest-xdist`) as it should work correctly now.  It also introduces a change in the CI workflow config to only allow running one workflow at a time.

**This should be reviewed together with [these corresponding changes in the SDK](https://github.com/Backblaze/b2-sdk-python/pull/349).**

**Tests will fail unless #821 and #818 are merged to master.**  (These will fail on the master branch with the latest SDK version from master too).