### PR TITLE
Fix failing test_keys unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Infrastructure
 * Fix warnings in tests
+* Fix `test_keys` unit test after changes in b2sdk
 
 ## [3.5.0] - 2022-07-27
 

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -626,6 +626,12 @@ class TestConsoleTool(BaseConsoleToolTest):
             '',
             0,
         )
+        self._run_command(
+            ['create-key', '--bucket', 'my-bucket-b', 'goodKeyName-Five', capabilities_with_commas],
+            'appKeyId4 appKey4\n',
+            '',
+            0,
+        )
 
         # Delete one key
         self._run_command(['delete-key', 'appKeyId2'], 'appKeyId2\n', '', 0)
@@ -637,15 +643,15 @@ class TestConsoleTool(BaseConsoleToolTest):
         expected_list_keys_out = """
             appKeyId0   goodKeyName-One
             appKeyId1   goodKeyName-Two
-            appKeyId2   goodKeyName-Three
             appKeyId3   goodKeyName-Four
+            appKeyId4   goodKeyName-Five
             """
 
         expected_list_keys_out_long = """
             appKeyId0   goodKeyName-One        -                      -            -          ''   readFiles,listBuckets
             appKeyId1   goodKeyName-Two        my-bucket-a            -            -          ''   readFiles,listBuckets,readBucketEncryption
-            appKeyId2   goodKeyName-Three      id=bucket_1            -            -          ''   readFiles,listBuckets
             appKeyId3   goodKeyName-Four       -                      -            -          ''   %s
+            appKeyId4   goodKeyName-Five       id=bucket_1            -            -          ''   readFiles,listBuckets
             """ % (','.join(ALL_CAPABILITIES),)
 
         self._run_command(['list-keys'], expected_list_keys_out, '', 0)


### PR DESCRIPTION
This is a fix for the `test_keys` unit tests, which started failing after commit [043b919](https://github.com/Backblaze/b2-sdk-python/commit/043b919de9f43ca88f690f695631fd354b02a32f) (_Fix B2Api.get_key() returning wrong key if `key_id` is incorrect_) was added to b2sdk.

Update: Turns out there was another failing test -- `test_replication_monitoring` in the integration suite.  This one started failing with this change in the SDK: [fd1ee02](https://github.com/Backblaze/b2-sdk-python/commit/fd1ee02).  This is now fixed too.