### PR TITLE
Fetching command class from parsed arguments instead of registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7", "3.11"]
         exclude:
           - os: "macos-latest"
             python-version: "pypy-3.7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Stop using b2sdk.v1 in arg_parser.py
+* Fix issues when running commands on Python 3.11
 
 ## [3.6.0] - 2022-09-20
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,13 @@ INSTALL_SDK_FROM = os.environ.get('INSTALL_SDK_FROM')
 NO_STATICX = os.environ.get('NO_STATICX') is not None
 NOX_PYTHONS = os.environ.get('NOX_PYTHONS')
 
-PYTHON_VERSIONS = ['3.7', '3.8', '3.9', '3.10'] if NOX_PYTHONS is None else NOX_PYTHONS.split(',')
+PYTHON_VERSIONS = [
+    '3.7',
+    '3.8',
+    '3.9',
+    '3.10',
+    '3.11',
+] if NOX_PYTHONS is None else NOX_PYTHONS.split(',')
 PYTHON_DEFAULT_VERSION = PYTHON_VERSIONS[-1]
 
 PY_PATHS = ['b2', 'test', 'noxfile.py', 'setup.py']


### PR DESCRIPTION
In Python `3.11` `argparse` `add_parser` doesn't allow registering the same name/alias multiple times. Multiple registration was used to ensure that we have both name and alias in class registry. By removing multiple registration and ensuring that class is assigned to the parser, we no longer need to fetch objects from registry during run – thus removing the issue entirely.