### PR TITLE
Disable changelog verification on pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Run linters
         run: nox -vs lint
       - name: Validate changelog
-        if: ${{ ! startsWith(github.ref, 'refs/heads/dependabot/') }}
+        # Library was designed to be used with pull requests only.
+        if: ${{ github.event_name == 'pull_request' && ! startsWith(github.ref, 'refs/heads/dependabot/') }}
         uses: zattoo/changelog@v1
         with:
           token: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Infrastructure
 * GitHub CI got checkout action updated to v3 and setup-python to v4
+* Ensured that changelog validation only happens on pull requests
 
 ## [3.6.0] - 2022-09-20
 


### PR DESCRIPTION
https://github.com/zattoo/changelog/issues/78#issuecomment-1318678862

Action creator confirmed that his project is intended for using only with pull requests. While it's possible that in the future it'll also perform validation for pushes, for now we should run it only against pull requests.

Note that the older version didn't fail just because of a deprecated behaviour that was finally removed.