### PR TITLE
Dockerfile

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -159,3 +159,34 @@ jobs:
           draft: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
           prerelease: false
           files: ${{ steps.sign.outputs.asset_path }}
+  deploy-docker:
+    needs: deploy
+    runs-on: ubuntu-latest
+    container:
+      image: "python:3.10"  # can not use ${{ env.PYTHON_DEFAULT_VERSION }} here
+      env:
+        DEBIAN_FRONTEND: noninteractive
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: python -m pip install --upgrade nox pip setuptools
+      - name: Build Dockerfile
+        id: build-dockerfile
+        run: nox -vs docker
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: backblaze/b2:${{ steps.build.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,26 @@ jobs:
       - name: Run integration tests
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
         run: nox -vs integration -- --cleanup
+  test-docker:
+    needs: cleanup_buckets
+    env:
+      B2_TEST_APPLICATION_KEY: ${{ secrets.B2_TEST_APPLICATION_KEY }}
+      B2_TEST_APPLICATION_KEY_ID: ${{ secrets.B2_TEST_APPLICATION_KEY_ID }}
+    runs-on: ubuntu-latest
+    # Running on raw machine.
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ PYTHON_DEFAULT_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ PYTHON_DEFAULT_VERSION }}
+      - name: Install dependencies
+        run: python -m pip install --upgrade nox pip setuptools
+      - name: Run dockerized tests
+        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
+        run: nox -vs docker_test
   test-linux-bundle:
     needs: cleanup_buckets
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage.xml
 dist
 venv
 doc/source/main_help.rst
+Dockerfile

--- a/README.md
+++ b/README.md
@@ -78,6 +78,31 @@ determine if there are benefits.
 
 Note that using multiple threads will usually be detrimental to the other users on your network.
 
+## Docker image
+
+An official docker image is provided for these who want to use B2 Command Line Tool in a docker environment.
+
+Assuming that `b2-credentials-file` contains two lines:
+
+```env
+B2_APPLICATION_KEY=key
+B2_APPLICATION_KEY_ID=key-id
+```
+
+An example workflow could be:
+
+    docker run --env-file b2-credentials-file b2 authorize-account
+    docker run --env-file b2-credentials-file b2 create-bucket test-bucket allPrivate
+    docker run --env-file b2-credentials-file -v `pwd`:/data b2 upload-file test-bucket /data/local-file remote-file
+    docker run --env-file b2-credentials-file -v `pwd`:/data b2 ls test-bucket
+    docker run --env-file b2-credentials-file -v `pwd`:/data b2 download-file-by-name test-bucket remote-file /data/local-file-2
+
+Where `-v ``pwd``:/data` mounts current directory to a `/data` on the image. Notice that since you're running commands 
+from inside the docker image, you need to mount a drive to both upload and download files properly.
+
+Note that both account info file and SQLite database will be, by default, created on the image. Mounting docker volumes
+should be used to alter this behaviour.
+
 # Contrib
 
 ## bash completion


### PR DESCRIPTION
- `nox -s docker` spawns the Dockerfile
- `nox -s docker_test` spawns the Dockerfile and runs all the tests (units and integration) from it
- Readme updated with an example usage
- CI runs tests off the docker image
- CD deploys docker image to docker hub
- Readme is used as source of the labeled name and description

Example `Dockerfile` generated during the development:
``
FROM python:3.11-slim as base

RUN ["adduser", "--no-create-home", "--disabled-password", "--force-badname", "--quiet", "b2"]
RUN ["usermod", "--home", "/b2", "b2"]
USER b2

LABEL vendor=Backblaze
LABEL name="B2 Command Line Tool"
LABEL description="The command-line tool that gives easy access to all of the capabilities of B2 Cloud Storage."
LABEL version="1.4.3.dev599+gcfe80aa.d20221205"
LABEL url="https://www.backblaze.com"
LABEL vcs-url="https://github.com/Backblaze/B2_Command_Line_Tool"
LABEL vcs-ref="b5e2484af108c05cf5df56da439275f583079678"
LABEL build-date-iso8601="2022-12-06T13:01:42.947463"

WORKDIR /b2
COPY dist/b2-1.4.3.dev603+gb5e2484.d20221206.tar.gz .
RUN ["pip", "install", "b2-1.4.3.dev603+gb5e2484.d20221206.tar.gz"]
ENV PATH=/b2/.local/bin:$PATH


FROM base as test

WORKDIR /test
COPY test ./test
COPY noxfile.py .

# Files used by tests.
COPY README.md .
COPY CHANGELOG.md .

RUN ["pip", "install", "nox"]
ENTRYPOINT ["nox", "--no-venv", "--no-install", "-s"]


FROM base

ENTRYPOINT ["b2"]
CMD ["--help"]
``