### PR TITLE
Hashes of releases added

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,7 +43,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ steps.build.outputs.version }}
-          body: ${{ steps.read-changelog.outputs.log_entry }}
+          body: ${{ steps.read-changelog.outputs.changes }}
           draft: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
           prerelease: false
           files: ${{ steps.build.outputs.asset_path }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,21 +18,24 @@ jobs:
     outputs:
       version: ${{ steps.build.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python ${{ env.PYTHON_DEFAULT_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
       - name: Install dependencies
         run: python -m pip install --upgrade nox pip setuptools
       - name: Build the distribution
         id: build
-        run: nox -vs build
+        run: nox -vs build >> $GITHUB_OUTPUT
+      - name: Generate hashes
+        id: hashes
+        run: nox -vs make_dist_digest
       - name: Read the Changelog
         id: read-changelog
-        uses: mindsers/changelog-reader-action@v1
+        uses: mindsers/changelog-reader-action@v2
         with:
           version: ${{ steps.build.outputs.version }}
       - name: Create GitHub release and upload the distribution
@@ -58,7 +61,7 @@ jobs:
       env:
         DEBIAN_FRONTEND: noninteractive
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install dependencies
@@ -68,10 +71,13 @@ jobs:
           python -m pip install --upgrade nox pip setuptools
       - name: Bundle the distribution
         id: bundle
-        run: nox -vs bundle
+        run: nox -vs bundle >> $GITHUB_OUTPUT
       - name: Sign the bundle
         id: sign
-        run: nox -vs sign
+        run: nox -vs sign >> $GITHUB_OUTPUT
+      - name: Generate hashes
+        id: hashes
+        run: nox -vs make_dist_digest
       - name: Upload the bundle to the GitHub release
         uses: softprops/action-gh-release@v1
         with:
@@ -89,18 +95,18 @@ jobs:
       B2_OSX_NOTARY_PASSWORD: ${{ secrets.B2_OSX_NOTARY_PASSWORD }}
     runs-on: macos-10.15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python ${{ env.PYTHON_DEFAULT_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
       - name: Install dependencies
         run: python -m pip install --upgrade nox pip setuptools
       - name: Bundle the distribution
         id: bundle
-        run: nox -vs bundle
+        run: nox -vs bundle >> $GITHUB_OUTPUT
       - name: Import certificate
         uses: apple-actions/import-codesign-certs@v1
         with:
@@ -108,7 +114,7 @@ jobs:
           p12-password: ${{ env.B2_OSX_CODE_SIGNING_CERTIFICATE_PASSWORD }}
       - name: Sign the bundle
         id: sign
-        run: nox -vs sign -- '${{ env.B2_OSX_CODE_SIGNING_CERTIFICATE_NAME }}'
+        run: nox -vs sign -- '${{ env.B2_OSX_CODE_SIGNING_CERTIFICATE_NAME }}' >> $GITHUB_OUTPUT
       - name: Notarize the bundle
         if: ${{ env.B2_OSX_NOTARY_NAME != '' }}
         uses: devbotsxyz/xcode-notarize@v1
@@ -117,6 +123,9 @@ jobs:
           appstore-connect-username: ${{ env.B2_OSX_NOTARY_NAME }}
           appstore-connect-password: ${{ env.B2_OSX_NOTARY_PASSWORD }}
           primary-bundle-id: com.backblaze.b2
+      - name: Generate hashes
+        id: hashes
+        run: nox -vs make_dist_digest
       - name: Upload the bundle to the GitHub release
         uses: softprops/action-gh-release@v1
         with:
@@ -131,18 +140,19 @@ jobs:
       B2_WINDOWS_CODE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.B2_WINDOWS_CODE_SIGNING_CERTIFICATE_PASSWORD }}
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python ${{ env.PYTHON_DEFAULT_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
       - name: Install dependencies
         run: python -m pip install --upgrade nox pip setuptools
       - name: Bundle the distribution
         id: bundle
-        run: nox -vs bundle
+        shell: bash
+        run: nox -vs bundle >> $GITHUB_OUTPUT
       - name: Import certificate
         id: windows_import_cert
         uses: timheuer/base64-to-file@v1
@@ -151,7 +161,11 @@ jobs:
           encodedString: ${{ secrets.B2_WINDOWS_CODE_SIGNING_CERTIFICATE }}
       - name: Sign the bundle
         id: sign
-        run: nox -vs sign -- '${{ steps.windows_import_cert.outputs.filePath }}' '${{ env.B2_WINDOWS_CODE_SIGNING_CERTIFICATE_PASSWORD }}'
+        shell: bash
+        run: nox -vs sign -- '${{ steps.windows_import_cert.outputs.filePath }}' '${{ env.B2_WINDOWS_CODE_SIGNING_CERTIFICATE_PASSWORD }}' >> $GITHUB_OUTPUT
+      - name: Generate hashes
+        id: hashes
+        run: nox -vs make_dist_digest
       - name: Upload the bundle to the GitHub release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         run: nox -vs make_dist_digest
       - name: Run integration tests
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
-        run: nox -vs integration -- --sut=${{ steps.bundle.outputs.asset_path }} --cleanup
+        run: nox -vs integration -- --sut=${{ steps.bundle.outputs.sut_path }} --cleanup
       - name: Upload assets
         if: failure()
         uses: actions/upload-artifact@v2
@@ -159,13 +159,14 @@ jobs:
         run: python -m pip install --upgrade nox pip setuptools
       - name: Bundle the distribution
         id: bundle
+        shell: bash
         run: nox -vs bundle >> $GITHUB_OUTPUT
       - name: Generate hashes
         id: hashes
         run: nox -vs make_dist_digest
       - name: Run integration tests
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
-        run: nox -vs integration -- --sut=${{ steps.bundle.outputs.asset_path }} --cleanup
+        run: nox -vs integration -- --sut=${{ steps.bundle.outputs.sut_path }} --cleanup
       - name: Upload assets
         if: failure()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install dependencies
         run: python -m pip install --upgrade nox pip setuptools
       - name: Build the distribution
-        run: nox -vs build
+        run: nox -vs build >> $GITHUB_OUTPUT
   cleanup_buckets:
     needs: lint
     env:
@@ -123,7 +123,10 @@ jobs:
           python -m pip install --upgrade nox pip setuptools
       - name: Bundle the distribution
         id: bundle
-        run: nox -vs bundle
+        run: nox -vs bundle >> $GITHUB_OUTPUT
+      - name: Generate hashes
+        id: hashes
+        run: nox -vs make_dist_digest
       - name: Run integration tests
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
         run: nox -vs integration -- --sut=${{ steps.bundle.outputs.asset_path }} --cleanup
@@ -156,7 +159,10 @@ jobs:
         run: python -m pip install --upgrade nox pip setuptools
       - name: Bundle the distribution
         id: bundle
-        run: nox -vs bundle
+        run: nox -vs bundle >> $GITHUB_OUTPUT
+      - name: Generate hashes
+        id: hashes
+        run: nox -vs make_dist_digest
       - name: Run integration tests
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
         run: nox -vs integration -- --sut=${{ steps.bundle.outputs.asset_path }} --cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Infrastructure
 * GitHub CI got checkout action updated to v3 and setup-python to v4
 * Ensured that changelog validation only happens on pull requests
+* GitHub CI uses GITHUB_OUTPUT instead of deprecated set-output
+* Releases now feature digests of each file
 
 ## [3.6.0] - 2022-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Stop using b2sdk.v1 in arg_parser.py
 * Fix issues when running commands on Python 3.11
+* Fix tests after changes introduced in b2sdk 1.19.0
 
 ### Infrastructure
 * GitHub CI got checkout action updated to v3 and setup-python to v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -267,6 +267,9 @@ def bundle(session):
         # otherwise glob won't find files on windows in action-gh-release.
         print('asset_path=dist/*')
 
+        executable = str(next(pathlib.Path('dist').glob('*')))
+        print(f'sut_path={executable}')
+
 
 @nox.session(python=False)
 def sign(session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,15 +8,15 @@
 #
 ######################################################################
 
-import io
+import hashlib
 import os
-import pkg_resources
+import pathlib
 import platform
 import subprocess
-
 from glob import glob
 
 import nox
+import pkg_resources
 
 CI = os.environ.get('CI') is not None
 CD = CI and (os.environ.get('CD') is not None)
@@ -65,9 +65,18 @@ nox.options.sessions = [
     'test',
 ]
 
+run_kwargs = {}
+
 # In CI, use Python interpreter provided by GitHub Actions
 if CI:
     nox.options.force_venv_backend = 'none'
+
+    # Inside the CI we need to silence most of the outputs to be able to use GITHUB_OUTPUT properly.
+    # Nox passes `stderr` and `stdout` directly to subprocess.Popen.
+    run_kwargs = dict(
+        stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+    )
 
 
 def install_myself(session, extras=None):
@@ -77,7 +86,7 @@ def install_myself(session, extras=None):
     if extras:
         arg += '[%s]' % ','.join(extras)
 
-    session.run('pip', 'install', '-e', arg)
+    session.run('pip', 'install', '-e', arg, **run_kwargs)
 
     if INSTALL_SDK_FROM:
         cwd = os.getcwd()
@@ -218,42 +227,45 @@ def cover(session):
 def build(session):
     """Build the distribution."""
     # TODO: consider using wheel as well
-    session.run('pip', 'install', *REQUIREMENTS_BUILD)
-    session.run('python', 'setup.py', 'check', '--metadata', '--strict')
-    session.run('rm', '-rf', 'build', 'dist', 'b2.egg-info', external=True)
-    session.run('python', 'setup.py', 'sdist', *session.posargs)
+    session.run('pip', 'install', *REQUIREMENTS_BUILD, **run_kwargs)
+    session.run('python', 'setup.py', 'check', '--metadata', '--strict', **run_kwargs)
+    session.run('rm', '-rf', 'build', 'dist', 'b2.egg-info', external=True, **run_kwargs)
+    session.run('python', 'setup.py', 'sdist', *session.posargs, **run_kwargs)
 
     # Set outputs for GitHub Actions
     if CI:
-        asset_path = glob('dist/*')[0]
-        print('::set-output name=asset_path::', asset_path, sep='')
+        # Path have to be specified with unix style slashes even for windows,
+        # otherwise glob won't find files on windows in action-gh-release.
+        print('asset_path=dist/*')
 
         version = os.environ['GITHUB_REF'].replace('refs/tags/v', '')
-        print('::set-output name=version::', version, sep='')
+        print(f'version={version}')
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def bundle(session):
     """Bundle the distribution."""
-    session.run('pip', 'install', *REQUIREMENTS_BUNDLE)
-    session.run('rm', '-rf', 'build', 'dist', 'b2.egg-info', external=True)
+    session.run('pip', 'install', *REQUIREMENTS_BUNDLE, **run_kwargs)
+    session.run('rm', '-rf', 'build', 'dist', 'b2.egg-info', external=True, **run_kwargs)
     install_myself(session)
 
     if SYSTEM == 'darwin':
         session.posargs.extend(['--osx-bundle-identifier', OSX_BUNDLE_IDENTIFIER])
 
-    session.run('pyinstaller', '--onefile', *session.posargs, 'b2.spec')
+    session.run('pyinstaller', '--onefile', *session.posargs, 'b2.spec', **run_kwargs)
 
     if SYSTEM == 'linux' and not NO_STATICX:
         session.run(
-            'staticx', '--no-compress', '--strip', '--loglevel', 'INFO', 'dist/b2', 'dist/b2-static'
+            'staticx', '--no-compress', '--strip', '--loglevel', 'INFO', 'dist/b2',
+            'dist/b2-static', **run_kwargs
         )
-        session.run('mv', '-f', 'dist/b2-static', 'dist/b2', external=True)
+        session.run('mv', '-f', 'dist/b2-static', 'dist/b2', external=True, **run_kwargs)
 
     # Set outputs for GitHub Actions
     if CI:
-        asset_path = glob('dist/*')[0]
-        print('::set-output name=asset_path::', asset_path, sep='')
+        # Path have to be specified with unix style slashes even for windows,
+        # otherwise glob won't find files on windows in action-gh-release.
+        print('asset_path=dist/*')
 
 
 @nox.session(python=False)
@@ -261,7 +273,7 @@ def sign(session):
     """Sign the bundled distribution (macOS and Windows only)."""
 
     def sign_darwin(cert_name):
-        session.run('security', 'find-identity', external=True)
+        session.run('security', 'find-identity', external=True, **run_kwargs)
         session.run(
             'codesign',
             '--deep',
@@ -277,12 +289,13 @@ def sign(session):
             '--sign',
             cert_name,
             'dist/b2',
-            external=True
+            external=True,
+            **run_kwargs
         )
-        session.run('codesign', '--verify', '--verbose', 'dist/b2', external=True)
+        session.run('codesign', '--verify', '--verbose', 'dist/b2', external=True, **run_kwargs)
 
     def sign_windows(cert_file, cert_password):
-        session.run('certutil', '-f', '-p', cert_password, '-importpfx', cert_file)
+        session.run('certutil', '-f', '-p', cert_password, '-importpfx', cert_file, **run_kwargs)
         session.run(
             WINDOWS_SIGNTOOL_PATH,
             'sign',
@@ -297,9 +310,18 @@ def sign(session):
             '/fd',
             'sha256',
             'dist/b2.exe',
-            external=True
+            external=True,
+            **run_kwargs
         )
-        session.run(WINDOWS_SIGNTOOL_PATH, 'verify', '/pa', '/all', 'dist/b2.exe', external=True)
+        session.run(
+            WINDOWS_SIGNTOOL_PATH,
+            'verify',
+            '/pa',
+            '/all',
+            'dist/b2.exe',
+            external=True,
+            **run_kwargs
+        )
 
     if SYSTEM == 'darwin':
         try:
@@ -327,12 +349,50 @@ def sign(session):
     name, ext = os.path.splitext(os.path.basename(asset_old_path))
     asset_path = 'dist/{}-{}{}'.format(name, SYSTEM, ext)
 
-    session.run('mv', '-f', asset_old_path, asset_path, external=True)
+    session.run('mv', '-f', asset_old_path, asset_path, external=True, **run_kwargs)
 
     # Set outputs for GitHub Actions
     if CI:
-        asset_path = glob('dist/*')[0]
-        print('::set-output name=asset_path::', asset_path, sep='')
+        # Path have to be specified with unix style slashes even for windows,
+        # otherwise glob won't find files on windows in action-gh-release.
+        print('asset_path=dist/*')
+
+
+@nox.session(python=PYTHON_DEFAULT_VERSION)
+def make_dist_digest(_session):
+    wanted_algos = ['sha256', 'sha512', 'sha3_256', 'sha3_512']
+    available_algos = [algo for algo in wanted_algos if algo in hashlib.algorithms_available]
+    longest_algo_name = max([len(elem) for elem in available_algos])
+    line_format = '{algo:<%s} {hash_value}' % longest_algo_name
+
+    directory = pathlib.Path('dist')
+    glob_match = '*'
+
+    hashes_file_suffix = '_hashes'
+    did_find_any_file = False
+
+    # I assume that these files fit into ram.
+    for dist_file in directory.glob(glob_match):
+        if dist_file.stem.endswith(hashes_file_suffix):
+            continue
+
+        output_lines = []
+        data = dist_file.read_bytes()
+
+        for algo in available_algos:
+            hash_value = hashlib.new(algo, data).hexdigest()
+            output_lines.append(line_format.format(algo=algo, hash_value=hash_value))
+
+        # Writing as bytes to ensure that Windows won't add BOM to the file.
+        dist_file.with_stem(dist_file.name + hashes_file_suffix) \
+            .with_suffix('.txt') \
+            .write_bytes('\n'.join(output_lines).encode('ascii'))
+        did_find_any_file = True
+
+    if not did_find_any_file:
+        raise RuntimeError(
+            f'No file found in {str(directory / glob_match)}, but was expected to find some.'
+        )
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)

--- a/noxfile.py
+++ b/noxfile.py
@@ -380,7 +380,7 @@ def make_dist_digest(_session):
         if dist_file.stem.endswith(hashes_file_suffix):
             continue
 
-        algos_struct = {algo: hashlib.new(algo) for algo in available_algos}
+        hash_structs = [hashlib.new(algo) for algo in available_algos]
 
         with open(dist_file, 'rb') as f:
             while True:
@@ -388,14 +388,14 @@ def make_dist_digest(_session):
                 if not buffer:
                     break
 
-                for hash_struct in algos_struct.values():
+                for hash_struct in hash_structs:
                     hash_struct.update(buffer)
 
         output_lines = []
 
-        for algo, hash_struct in algos_struct.items():
+        for hash_struct in hash_structs:
             hash_value = hash_struct.hexdigest()
-            output_lines.append(line_format.format(algo=algo, hash_value=hash_value))
+            output_lines.append(line_format.format(algo=hash_struct.name, hash_value=hash_value))
 
         # Writing as bytes to ensure that Windows won't add BOM to the file.
         dist_file.with_stem(dist_file.name + hashes_file_suffix) \

--- a/noxfile.py
+++ b/noxfile.py
@@ -97,7 +97,8 @@ def install_myself(session, extras=None):
     elif CI and not CD:
         # In CI, install B2 SDK from the master branch
         session.run(
-            'pip', 'install', 'git+https://github.com/Backblaze/b2-sdk-python.git#egg=b2sdk'
+            'pip', 'install', 'git+https://github.com/Backblaze/b2-sdk-python.git#egg=b2sdk',
+            **run_kwargs
         )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -393,8 +393,8 @@ def make_dist_digest(_session):
 
         output_lines = []
 
-        for algo in available_algos:
-            hash_value = algos_struct[algo].hexdigest()
+        for algo, hash_struct in algos_struct.items():
+            hash_value = hash_struct.hexdigest()
             output_lines.append(line_format.format(algo=algo, hash_value=hash_value))
 
         # Writing as bytes to ensure that Windows won't add BOM to the file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arrow>=1.0.2,<2.0.0
-b2sdk>=1.18.0,<2.0.0
+b2sdk>=1.19.0,<2.0.0
 docutils==0.19
 idna>=2.2.0; platform_system == 'Java'
 importlib-metadata>=3.3.0; python_version < '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arrow>=1.0.2,<2.0.0
-b2sdk>=1.18.0
+b2sdk>=1.18.0,<2.0.0
 docutils==0.19
 idna>=2.2.0; platform_system == 'Java'
 importlib-metadata>=3.3.0; python_version < '3.8'

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -1384,10 +1384,11 @@ class TestConsoleTool(BaseConsoleToolTest):
                 "contentSha1": "none",
                 "contentType": "b2/x-auto",
                 "fileId": "9999",
-                "fileInfo": {
-                    "large_file_sha1": "cc8954ec25e0c564b6a693fb22200e4f832c18e8",
-                    "src_last_modified_millis": str(mod_time_str)
-                },
+                "fileInfo":
+                    {
+                        "large_file_sha1": "cc8954ec25e0c564b6a693fb22200e4f832c18e8",
+                        "src_last_modified_millis": str(mod_time_str)
+                    },
                 "fileName": "test.txt",
                 "serverSideEncryption": {
                     "mode": "none"
@@ -1426,10 +1427,11 @@ class TestConsoleTool(BaseConsoleToolTest):
                 "contentSha1": "none",
                 "contentType": "b2/x-auto",
                 "fileId": "9999",
-                "fileInfo": {
-                    "large_file_sha1": "cc8954ec25e0c564b6a693fb22200e4f832c18e8",
-                    "src_last_modified_millis": str(mod_time_str)
-                },
+                "fileInfo":
+                    {
+                        "large_file_sha1": "cc8954ec25e0c564b6a693fb22200e4f832c18e8",
+                        "src_last_modified_millis": str(mod_time_str)
+                    },
                 "fileName": "test.txt",
                 "serverSideEncryption": {
                     "algorithm": "AES256",

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -1385,6 +1385,7 @@ class TestConsoleTool(BaseConsoleToolTest):
                 "contentType": "b2/x-auto",
                 "fileId": "9999",
                 "fileInfo": {
+                    "large_file_sha1": "cc8954ec25e0c564b6a693fb22200e4f832c18e8",
                     "src_last_modified_millis": str(mod_time_str)
                 },
                 "fileName": "test.txt",
@@ -1426,6 +1427,7 @@ class TestConsoleTool(BaseConsoleToolTest):
                 "contentType": "b2/x-auto",
                 "fileId": "9999",
                 "fileInfo": {
+                    "large_file_sha1": "cc8954ec25e0c564b6a693fb22200e4f832c18e8",
                     "src_last_modified_millis": str(mod_time_str)
                 },
                 "fileName": "test.txt",
@@ -2174,7 +2176,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         self._run_command(
             ['authorize-account', 'appKeyId0', 'appKey0'],
             'Using http://production.example.com\n',
-            "ERROR: application key is restricted to bucket id 'bucket_0', which no longer exists\n",
+            "ERROR: unable to authorize account: Application key is restricted to a bucket that doesn't exist\n",
             1,
         )
 

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -2171,29 +2171,12 @@ class TestConsoleTool(BaseConsoleToolTest):
 
         # Authorizing with the key will fail because the ConsoleTool needs
         # to be able to look up the name of the bucket.
-
-        # In the latest version the error code changed, so we keep the old and the new for the resting purposes.
-        # TODO: remove the `except` part after 1.19.0 b2sdk is released
-        new_message = "ERROR: unable to authorize account: Application key is restricted to a bucket that doesn't exist\n"
-        old_message = "ERROR: application key is restricted to bucket id 'bucket_0', which no longer exists\n"
-        try:
-            self._run_command(
-                ['authorize-account', 'appKeyId0', 'appKey0'],
-                'Using http://production.example.com\n',
-                new_message,
-                1,
-            )
-        except AssertionError as ex:
-            # If we got the whole old message in our exception, it means that we're handling the old version still.
-            if old_message not in str(ex):
-                raise
-            # Ensure that the command runs as expected anyway.
-            self._run_command(
-                ['authorize-account', 'appKeyId0', 'appKey0'],
-                'Using http://production.example.com\n',
-                old_message,
-                1,
-            )
+        self._run_command(
+            ['authorize-account', 'appKeyId0', 'appKey0'],
+            'Using http://production.example.com\n',
+            "ERROR: application key is restricted to bucket id 'bucket_0', which no longer exists\n",
+            1,
+        )
 
     def test_ls_for_restricted_bucket(self):
         # Create a bucket and a key restricted to that bucket.

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -2171,12 +2171,29 @@ class TestConsoleTool(BaseConsoleToolTest):
 
         # Authorizing with the key will fail because the ConsoleTool needs
         # to be able to look up the name of the bucket.
-        self._run_command(
-            ['authorize-account', 'appKeyId0', 'appKey0'],
-            'Using http://production.example.com\n',
-            "ERROR: application key is restricted to bucket id 'bucket_0', which no longer exists\n",
-            1,
-        )
+
+        # In the latest version the error code changed, so we keep the old and the new for the resting purposes.
+        # TODO: remove the `except` part after 1.19.0 b2sdk is released
+        new_message = "ERROR: unable to authorize account: Application key is restricted to a bucket that doesn't exist\n"
+        old_message = "ERROR: application key is restricted to bucket id 'bucket_0', which no longer exists\n"
+        try:
+            self._run_command(
+                ['authorize-account', 'appKeyId0', 'appKey0'],
+                'Using http://production.example.com\n',
+                new_message,
+                1,
+            )
+        except AssertionError as ex:
+            # If we got the whole old message in our exception, it means that we're handling the old version still.
+            if old_message not in str(ex):
+                raise
+            # Ensure that the command runs as expected anyway.
+            self._run_command(
+                ['authorize-account', 'appKeyId0', 'appKey0'],
+                'Using http://production.example.com\n',
+                old_message,
+                1,
+            )
 
     def test_ls_for_restricted_bucket(self):
         # Create a bucket and a key restricted to that bucket.


### PR DESCRIPTION
- Each release file receives a `_hashes.txt` file that contains several hex digests of the file.

Piggyback:
- upgraded github workflows versions when applicable to the latest one
- using `GITHUB_OUTPUT` instead of deprecated `set-output`
- limited `b2sdk` `requirements.txt` version to `2.0.0`
- fixes tests for `b2sdk` `1.19.0`, made it the baseline required version