### PR TITLE
fix integration tests erroring out when tested b2 package was not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Infrastructure
+* Autocomplete integration tests will now work properly even if tested package has not been installed
+
 ## [3.9.0] - 2023-04-28
 
 ### Added


### PR DESCRIPTION
Before this IF tested b2 package was not installed test will fail 100%.
What is even worse, if there was any other b2 version installed, this test would have run that one instead of the one from the local working directory.