### PR TITLE
Fix Fast rm sometimes fails unit tests #872

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update pyinstaller to fix Linux Bundle build
 
 ### Fixed
-* Fast rm sometimes fails unit tests
+* Fast rm sometimes failing due to a rare race condition
 
 ## [3.9.0] - 2023-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Autocomplete integration tests will now work properly even if tested package has not been installed
 * Automatically set copyright date when generating the docs
 
+### Fixed
+* Fast rm sometimes fails unit tests
+
 ## [3.9.0] - 2023-04-28
 
 ### Added

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -2030,7 +2030,7 @@ class Rm(AbstractLsCommand):
                 if self.fail_fast_event.is_set():
                     break
 
-                self .reporter.update_total(1)
+                self.reporter.update_total(1)
                 future = executor.submit(
                     self.runner.api.delete_file_version,
                     file_version.id_,
@@ -2049,6 +2049,7 @@ class Rm(AbstractLsCommand):
 
             try:
                 future.result()
+                self.reporter.update_count(1)
             except FileNotPresent:
                 # We wanted to remove this file anyway.
                 pass
@@ -2062,7 +2063,6 @@ class Rm(AbstractLsCommand):
             except Exception as error:
                 self.messages_queue.put((self.EXCEPTION_TAG, error))
             finally:
-                self.reporter.update_count(1)
                 self.semaphore.release()
 
     @classmethod

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -2052,7 +2052,7 @@ class Rm(AbstractLsCommand):
                 self.reporter.update_count(1)
             except FileNotPresent:
                 # We wanted to remove this file anyway.
-                pass
+                self.reporter.update_count(1)
             except B2Error as error:
                 if self.args.failFast:
                     # This is set before releasing the semaphore.

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -2030,6 +2030,7 @@ class Rm(AbstractLsCommand):
                 if self.fail_fast_event.is_set():
                     break
 
+                self .reporter.update_total(1)
                 future = executor.submit(
                     self.runner.api.delete_file_version,
                     file_version.id_,
@@ -2040,7 +2041,6 @@ class Rm(AbstractLsCommand):
                 # Done callback is added after, so it's "sure" that mapping is updated earlier.
                 future.add_done_callback(self._removal_done)
 
-                self.reporter.update_total(1)
             self.reporter.end_total()
 
         def _removal_done(self, future: Future) -> None:

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -2656,7 +2656,7 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         # we can only rely on the log to tell when it stopped.
         expected_in_stdout = '''
         Deletion of file "b/b1/test.csv" (9996) failed: Conflict:
-         count: 4/4'''
+         count: 3/4'''
         unexpected_in_stdout = ' count: 5/5 '
         self._run_problematic_removal(['--failFast'], expected_in_stdout, unexpected_in_stdout)
 


### PR DESCRIPTION
This pull request fixes race condition and reporter count update problems as reported in https://github.com/Backblaze/B2_Command_Line_Tool/issues/872.

The first fix is to ensure update_total is called before a task is submitted to the executor. This change was necessary to prevent a race condition in which the task could potentially finish before update_total is called, leading to unpredictable test outcomes. By ensuring that update_total is called before the task submission, we guarantee that the total count is always accurate at the time of task execution.

The second fix improves the updating of the reporter count. Initially, the reporter count was being updated before the future result was obtained, which could lead to inaccurate count values if the future result returned an exception. To make the tests more predictable and the reporter count more accurate, I modified the _removal_done function to only update the reporter's count after a successful future result. This ensures that the count is updated only when we are certain that the file has been deleted successfully. The test assert condition was updated to reflect this change.