### PR TITLE
Fix UnicodeEncodeError in Non-UTF8 Terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update pyinstaller to fix Linux Bundle build
 * Replace `pyflakes` with `ruff` for linting
 
+### Fixed
+* Fix UnicodeEncodeError in non-Unicode terminals by prioritizing stdout encoding
+
 ## [3.9.0] - 2023-04-28
 
 ### Added

--- a/b2/arg_parser.py
+++ b/b2/arg_parser.py
@@ -91,8 +91,15 @@ class ArgumentParser(argparse.ArgumentParser):
     @classmethod
     def _get_encoding(cls):
         _, locale_encoding = locale.getdefaultlocale()
-        if locale_encoding is not None:
-            return sys.getdefaultencoding()
+
+        # Check if the stdout is properly set
+        if sys.stdout.encoding is not None:
+            # Use the stdout encoding
+            return sys.stdout.encoding
+
+        # Fall back to the locale_encoding if stdout encoding is not set
+        elif locale_encoding is not None:
+            return locale_encoding
 
         # locales are improperly configured
         return 'ascii'

--- a/test/unit/test_arg_parser.py
+++ b/test/unit/test_arg_parser.py
@@ -88,4 +88,3 @@ class TestNonUTF8TerminalSupport(TestBase):
         for command_name, command_class in command_classes.items():
             with self.subTest(command_class=command_class, command_name=command_name):
                 self.check_help_string(command_class, command_name)
-

--- a/test/unit/test_arg_parser.py
+++ b/test/unit/test_arg_parser.py
@@ -86,7 +86,6 @@ class TestNonUTF8TerminalSupport(TestBase):
         command_classes = B2.subcommands_registry.get_all()
         command_classes.append(B2)
 
-
         for command_class in command_classes:
             with self.subTest(command_class=command_class):
                 self.check_help_string(command_class)

--- a/test/unit/test_arg_parser.py
+++ b/test/unit/test_arg_parser.py
@@ -9,8 +9,53 @@
 ######################################################################
 
 import argparse
+import sys
 
-from b2.arg_parser import parse_comma_separated_list, parse_millis_from_float_timestamp, parse_range
+from b2.arg_parser import (
+    ArgumentParser,
+    parse_comma_separated_list,
+    parse_millis_from_float_timestamp,
+    parse_range,
+)
+from b2.console_tool import (
+    B2,
+    AuthorizeAccount,
+    CancelAllUnfinishedLargeFiles,
+    CancelLargeFile,
+    ClearAccount,
+    CopyFileById,
+    CreateBucket,
+    CreateKey,
+    DeleteBucket,
+    DeleteFileVersion,
+    DeleteKey,
+    DownloadFileById,
+    DownloadFileByName,
+    GetAccountInfo,
+    GetBucket,
+    GetDownloadAuth,
+    GetDownloadUrlWithAuth,
+    HideFile,
+    InstallAutocomplete,
+    License,
+    ListBuckets,
+    ListKeys,
+    ListParts,
+    ListUnfinishedLargeFiles,
+    Ls,
+    MakeUrl,
+    ReplicationDelete,
+    ReplicationPause,
+    ReplicationSetup,
+    ReplicationStatus,
+    ReplicationUnpause,
+    Rm,
+    Sync,
+    UpdateBucket,
+    UpdateFileLegalHold,
+    UpdateFileRetention,
+    UploadFile,
+)
 
 from .test_base import TestBase
 
@@ -34,3 +79,88 @@ class TestCustomArgTypes(TestBase):
             parse_range('1,2,3')
         with self.assertRaises(ValueError):
             parse_range('!@#,%^&')
+
+
+class TestNonUTF8TerminalSupport(TestBase):
+    class ASCIIEncodedStream:
+        def __init__(self, original_stream):
+            self.original_stream = original_stream
+            self.encoding = 'ascii'
+
+        def write(self, data):
+            if isinstance(data, str):
+                data = data.encode(self.encoding, 'strict')
+            self.original_stream.buffer.write(data)
+
+        def flush(self):
+            self.original_stream.flush()
+
+    def check_help_string(self, command_class):
+        help_string = command_class.__doc__
+        command_name = command_class.__name__.lower()
+
+        # create a parser with a help message that is based on the command_class.__doc__ string
+        parser = ArgumentParser(description=help_string)
+
+        try:
+            old_stdout = sys.stdout
+            old_stderr = sys.stderr
+            sys.stdout = TestNonUTF8TerminalSupport.ASCIIEncodedStream(sys.stdout)
+            sys.stderr = TestNonUTF8TerminalSupport.ASCIIEncodedStream(sys.stderr)
+
+            parser.print_help()
+
+        except UnicodeEncodeError as e:
+            self.fail(
+                f'Failed to encode help message for command "{command_name}" on a non-UTF-8 terminal: {e}'
+            )
+
+        finally:
+            # Restore original stdout and stderr
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+
+    def test_help_in_non_utf8_terminal(self):
+        command_classes = [
+            AuthorizeAccount,
+            CancelAllUnfinishedLargeFiles,
+            CancelLargeFile,
+            ClearAccount,
+            CopyFileById,
+            CreateBucket,
+            DeleteBucket,
+            DeleteFileVersion,
+            DeleteKey,
+            DownloadFileById,
+            DownloadFileByName,
+            GetBucket,
+            GetDownloadAuth,
+            GetDownloadUrlWithAuth,
+            HideFile,
+            ListBuckets,
+            ListKeys,
+            ListParts,
+            ListUnfinishedLargeFiles,
+            Ls,
+            Rm,
+            MakeUrl,
+            Sync,
+            UpdateBucket,
+            UploadFile,
+            UpdateFileLegalHold,
+            UpdateFileRetention,
+            ReplicationSetup,
+            ReplicationDelete,
+            ReplicationPause,
+            ReplicationUnpause,
+            ReplicationStatus,
+            License,
+            InstallAutocomplete,
+            CreateKey,
+            GetAccountInfo,
+            B2,
+        ]
+
+        for command_class in command_classes:
+            with self.subTest(command_class=command_class):
+                self.check_help_string(command_class)

--- a/test/unit/test_arg_parser.py
+++ b/test/unit/test_arg_parser.py
@@ -17,45 +17,7 @@ from b2.arg_parser import (
     parse_millis_from_float_timestamp,
     parse_range,
 )
-from b2.console_tool import (
-    B2,
-    AuthorizeAccount,
-    CancelAllUnfinishedLargeFiles,
-    CancelLargeFile,
-    ClearAccount,
-    CopyFileById,
-    CreateBucket,
-    CreateKey,
-    DeleteBucket,
-    DeleteFileVersion,
-    DeleteKey,
-    DownloadFileById,
-    DownloadFileByName,
-    GetAccountInfo,
-    GetBucket,
-    GetDownloadAuth,
-    GetDownloadUrlWithAuth,
-    HideFile,
-    InstallAutocomplete,
-    License,
-    ListBuckets,
-    ListKeys,
-    ListParts,
-    ListUnfinishedLargeFiles,
-    Ls,
-    MakeUrl,
-    ReplicationDelete,
-    ReplicationPause,
-    ReplicationSetup,
-    ReplicationStatus,
-    ReplicationUnpause,
-    Rm,
-    Sync,
-    UpdateBucket,
-    UpdateFileLegalHold,
-    UpdateFileRetention,
-    UploadFile,
-)
+from b2.console_tool import B2
 
 from .test_base import TestBase
 
@@ -121,45 +83,9 @@ class TestNonUTF8TerminalSupport(TestBase):
             sys.stderr = old_stderr
 
     def test_help_in_non_utf8_terminal(self):
-        command_classes = [
-            AuthorizeAccount,
-            CancelAllUnfinishedLargeFiles,
-            CancelLargeFile,
-            ClearAccount,
-            CopyFileById,
-            CreateBucket,
-            DeleteBucket,
-            DeleteFileVersion,
-            DeleteKey,
-            DownloadFileById,
-            DownloadFileByName,
-            GetBucket,
-            GetDownloadAuth,
-            GetDownloadUrlWithAuth,
-            HideFile,
-            ListBuckets,
-            ListKeys,
-            ListParts,
-            ListUnfinishedLargeFiles,
-            Ls,
-            Rm,
-            MakeUrl,
-            Sync,
-            UpdateBucket,
-            UploadFile,
-            UpdateFileLegalHold,
-            UpdateFileRetention,
-            ReplicationSetup,
-            ReplicationDelete,
-            ReplicationPause,
-            ReplicationUnpause,
-            ReplicationStatus,
-            License,
-            InstallAutocomplete,
-            CreateKey,
-            GetAccountInfo,
-            B2,
-        ]
+        command_classes = B2.subcommands_registry.get_all()
+        command_classes.append(B2)
+
 
         for command_class in command_classes:
             with self.subTest(command_class=command_class):

--- a/test/unit/test_arg_parser.py
+++ b/test/unit/test_arg_parser.py
@@ -57,9 +57,8 @@ class TestNonUTF8TerminalSupport(TestBase):
         def flush(self):
             self.original_stream.flush()
 
-    def check_help_string(self, command_class):
+    def check_help_string(self, command_class, command_name):
         help_string = command_class.__doc__
-        command_name = command_class.__name__.lower()
 
         # create a parser with a help message that is based on the command_class.__doc__ string
         parser = ArgumentParser(description=help_string)
@@ -83,9 +82,10 @@ class TestNonUTF8TerminalSupport(TestBase):
             sys.stderr = old_stderr
 
     def test_help_in_non_utf8_terminal(self):
-        command_classes = B2.subcommands_registry.get_all()
-        command_classes.append(B2)
+        command_classes = dict(B2.subcommands_registry.items())
+        command_classes['b2'] = B2
 
-        for command_class in command_classes:
-            with self.subTest(command_class=command_class):
-                self.check_help_string(command_class)
+        for command_name, command_class in command_classes.items():
+            with self.subTest(command_class=command_class, command_name=command_name):
+                self.check_help_string(command_class, command_name)
+


### PR DESCRIPTION
This PR addresses an issue (https://github.com/Backblaze/B2_Command_Line_Tool/issues/888) where executing b2 --help in a non-UTF8 terminal would raise a UnicodeEncodeError due to improper handling of Unicode characters. The fix ensures that Unicode characters are correctly encoded irrespective of the terminal's locale. Unit tests have been added to prevent this issue from reoccurring in future releases.