### PR TITLE
fix resetting lifecycle rules in `update-bucket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fix resetting lifecycle rules in `update-bucket` command. 
+
 ## [3.10.0] - 2023-09-10
 
 ### Added

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -549,7 +549,7 @@ class LifecycleRulesMixin(Described):
         lifecycle_group.add_argument(
             '--lifecycleRule',
             action='append',
-            default=[],
+            default=None,
             type=functools.partial(validated_loads, expected_type=LifecycleRule),
             dest='lifecycleRules',
             help="Lifecycle rule in JSON format. Can be supplied multiple times.",

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -523,6 +523,42 @@ class TestConsoleTool(BaseConsoleToolTest):
             0,
         )
 
+    def test_update_bucket_without_lifecycle(self):
+        # Start with authorizing with the master key
+        self._authorize_account()
+
+        bucket_name = 'my-bucket-liferules'
+        # Create a bucket with lifecycleRule
+        self._run_command([
+            'create-bucket',
+            '--lifecycleRule',
+            '{"daysFromHidingToDeleting": 2, "fileNamePrefix": "foo"}',
+            bucket_name,
+            'allPrivate'],
+            'bucket_0\n', '', 0)
+
+        expected_stdout_dict = {
+            "accountId": self.account_id,
+            "bucketId": "bucket_0",
+            "bucketInfo": {
+                "xxx": "123"
+            },
+            "bucketName": "my-bucket-liferules",
+            "bucketType": "allPrivate",
+            "lifecycleRules": [
+                {
+                    "daysFromHidingToDeleting": 2,
+                    "fileNamePrefix": "foo"
+                }
+            ],
+        }
+
+        # Update some other attribute than lifecycleRule, which should remain intact
+        self._run_command(
+            ['update-bucket', bucket_name, '--bucketInfo', '{"xxx": "123"}'],
+            expected_json_in_stdout=expected_stdout_dict,
+        )
+
     def test_clear_account(self):
         # Initial condition
         self._authorize_account()


### PR DESCRIPTION
- default value for `--lifecycleRule` was `[]` which is not considered as _not-set_ value, so the rules were updated as such (ie. empty).