### PR TITLE
set `--noProgress` implicitly if `--quiet` was selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* `--quiet` now will implicitly set `--noProgress` option as well
+
 ## [3.11.0] - 2023-10-04
 
 ### Added


### PR DESCRIPTION
Fixes something we missed in  #924 

This **may** fix Mac integration tests errors we have been seeing as well.