### PR TITLE
feat: build docker image for arm architecture

### DIFF
--- a/.github/workflows/push_docker.yml
+++ b/.github/workflows/push_docker.yml
@@ -11,8 +11,6 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       DOCKERHUB_USERNAME: secrets.DOCKERHUB_USERNAME
       DOCKERHUB_TOKEN: secrets.DOCKERHUB_TOKEN
-      B2_TEST_APPLICATION_KEY: ${{ secrets.B2_TEST_APPLICATION_KEY }}
-      B2_TEST_APPLICATION_KEY_ID: ${{ secrets.B2_TEST_APPLICATION_KEY_ID }}
       PYTHON_DEFAULT_VERSION: 3.11
     steps:
       - uses: actions/checkout@v3
@@ -50,5 +48,4 @@ jobs:
           context: .
           push: true
           tags: backblazeit/b2:latest,backblazeit/b2:${{ steps.package_version.outputs.package_version }}
-          platforms: linux/amd64
-
+          platforms: linux/amd64,linux/arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Add linux/arm64 as a build platform for the official Docker image
+
 ### Fixed
 * Emit `Using https://api.backblazeb2.com` message to stderr instead of stdout, therefor prevent JSON output corruption
 


### PR DESCRIPTION
- add `linux/arm64` as a platform which is the default for running docker images on Apple Silicon (tested on https://hub.docker.com/r/yedpodtrzitko/b2/ )
- remove B2 env. variables as these are unused in given action file

