### PR TITLE
fix docker cmd example so it works properly on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Infrastructure
+* Fix `docker run` example in README.md
+
 ## [3.13.0] - 2023-11-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ docker run --rm -v b2:/root backblazeit/b2:latest list-buckets  # remember to in
 When uploading a single file, data can be passed to the container via a pipe:
 
 ```bash
-cat source_file.txt | docker run --rm -v b2:/root backblazeit/b2:latest upload-unbound-stream bucket_name - target_file_name
+cat source_file.txt | docker run -i --rm -v b2:/root backblazeit/b2:latest upload-unbound-stream bucket_name - target_file_name
 ```
 
 or by mounting local files in the docker container:


### PR DESCRIPTION
without `-i` it fails with very ugly error on linux as AFAIK can tell it is basically /dev/null without it