### PR TITLE
Header args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Add `--expires`, `--content-disposition`, `--content-encoding`, `--content-language` options to subcommands `upload-file`, `upload-unbound-stream`, `copy-file-by-id`
 
 ### Infrastructure
 * Fix `docker run` example in README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
 * Add `--expires`, `--content-disposition`, `--content-encoding`, `--content-language` options to subcommands `upload-file`, `upload-unbound-stream`, `copy-file-by-id`
 
 ### Infrastructure

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1053,6 +1053,21 @@ class CopyFileById(
         parser.add_argument('--metadataDirective', default=None, help=argparse.SUPPRESS)
         parser.add_argument('--contentType')
         parser.add_argument('--range', type=parse_range)
+        parser.add_argument(
+            '--cache-control', help='Add Cache-Control header' # TODO(vbaltrusaitis-reef): better description
+        )
+        parser.add_argument(
+            '--content-disposition', help='Add Content-Disposition header' # TODO(vbaltrusaitis-reef): better description
+        )
+        parser.add_argument(
+            '--content-language', help='Add Content-Language header' # TODO(vbaltrusaitis-reef): better description
+        )
+        parser.add_argument(
+            '--content-encoding', help='Add Content-Encoding header' # TODO(vbaltrusaitis-reef): better description
+        )
+        parser.add_argument(
+            '--expires', help='Add Expires header' # TODO(vbaltrusaitis-reef): better description
+        )
 
         info_group = parser.add_mutually_exclusive_group()
 
@@ -1111,6 +1126,11 @@ class CopyFileById(
             file_retention=file_retention,
             source_file_info=source_file_info,
             source_content_type=source_content_type,
+            cache_control=args.cache_control,
+            expires=args.expires,
+            content_disposition=args.content_disposition,
+            content_encoding=args.content_encoding,
+            content_language=args.content_language,
         )
         self._print_json(file_version)
         return 0
@@ -2890,6 +2910,18 @@ class UploadFileMixin(
         )
         parser.add_argument('--cache-control', default=None)
         parser.add_argument(
+            '--content-disposition', help='Add Content-Disposition header' # TODO(vbaltrusaitis-reef): better description
+        )
+        parser.add_argument(
+            '--content-language', help='Add Content-Language header' # TODO(vbaltrusaitis-reef): better description
+        )
+        parser.add_argument(
+            '--content-encoding', help='Add Content-Encoding header' # TODO(vbaltrusaitis-reef): better description
+        )
+        parser.add_argument(
+            '--expires', help='Add Expires header' # TODO(vbaltrusaitis-reef): better description
+        )
+        parser.add_argument(
             '--info',
             action='append',
             default=[],
@@ -2940,12 +2972,20 @@ class UploadFileMixin(
                 self.api.get_bucket_by_name(args.bucketName),
             "cache_control":
                 args.cache_control,
+            "content_disposition":
+                args.content_disposition,
+            "content_encoding":
+                args.content_encoding,
+            "content_language":
+                args.content_language,
             "content_type":
                 args.contentType,
             "custom_upload_timestamp":
                 args.custom_upload_timestamp,
             "encryption":
                 self._get_destination_sse_setting(args),
+            "expires":
+                args.expires,
             "file_info":
                 file_infos,
             "file_name":

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1054,19 +1054,19 @@ class CopyFileById(
         parser.add_argument('--contentType')
         parser.add_argument('--range', type=parse_range)
         parser.add_argument(
-            '--cache-control', help='Add Cache-Control header' # TODO(vbaltrusaitis-reef): better description
+            '--cache-control', help="optional Cache-Control header, value based on RFC 2616 section 14.9, example: 'public, max-age=86400')"
         )
         parser.add_argument(
-            '--content-disposition', help='Add Content-Disposition header' # TODO(vbaltrusaitis-reef): better description
+            '--content-disposition', help="optional Content-Disposition header, value based on RFC 2616 section 19.5.1, example: 'attachment; filename=\"fname.ext\"'"
         )
         parser.add_argument(
-            '--content-language', help='Add Content-Language header' # TODO(vbaltrusaitis-reef): better description
+            '--content-encoding', help="optional Content-Encoding header, value based on RFC 2616 section 14.11, example: 'gzip'"
         )
         parser.add_argument(
-            '--content-encoding', help='Add Content-Encoding header' # TODO(vbaltrusaitis-reef): better description
+            '--content-language', help="optional Content-Language header, value based on RFC 2616 section 14.12, example: 'mi, EN_US'"
         )
         parser.add_argument(
-            '--expires', help='Add Expires header' # TODO(vbaltrusaitis-reef): better description
+            '--expires', help="optional Expires header, value based on RFC 2616 section 14.21, example: 'Thu, 01 Dec 2050 16:00:00 GMT'"
         )
 
         info_group = parser.add_mutually_exclusive_group()
@@ -1381,6 +1381,8 @@ class DownloadCommand(Command):
             'Legal hold', self._represent_legal_hold(download_version.legal_hold)
         )
         for label, attr_name in [
+            ('CacheControl', 'cache_control'),
+            ('Expires', 'expires'),
             ('ContentDisposition', 'content_disposition'),
             ('ContentLanguage', 'content_language'),
             ('ContentEncoding', 'content_encoding'),
@@ -2908,18 +2910,20 @@ class UploadFileMixin(
         parser.add_argument(
             '--sha1', help="SHA-1 of the data being uploaded for verifying file integrity"
         )
-        parser.add_argument('--cache-control', default=None)
         parser.add_argument(
-            '--content-disposition', help='Add Content-Disposition header' # TODO(vbaltrusaitis-reef): better description
+            '--cache-control', help="optional Cache-Control header, value based on RFC 2616 section 14.9, example: 'public, max-age=86400')"
         )
         parser.add_argument(
-            '--content-language', help='Add Content-Language header' # TODO(vbaltrusaitis-reef): better description
+            '--content-disposition', help="optional Content-Disposition header, value based on RFC 2616 section 19.5.1, example: 'attachment; filename=\"fname.ext\"'"
         )
         parser.add_argument(
-            '--content-encoding', help='Add Content-Encoding header' # TODO(vbaltrusaitis-reef): better description
+            '--content-encoding', help="optional Content-Encoding header, value based on RFC 2616 section 14.11, example: 'gzip'"
         )
         parser.add_argument(
-            '--expires', help='Add Expires header' # TODO(vbaltrusaitis-reef): better description
+            '--content-language', help="optional Content-Language header, value based on RFC 2616 section 14.12, example: 'mi, EN_US'"
+        )
+        parser.add_argument(
+            '--expires', help="optional Expires header, value based on RFC 2616 section 14.21, example: 'Thu, 01 Dec 2050 16:00:00 GMT'"
         )
         parser.add_argument(
             '--info',

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1071,7 +1071,7 @@ class CopyFileById(
         parser.add_argument(
             '--content-language',
             help=
-            "optional Content-Language header, value based on RFC 2616 section 14.12, example: 'mi, EN_US'"
+            "optional Content-Language header, value based on RFC 2616 section 14.12, example: 'mi, en'"
         )
         parser.add_argument(
             '--expires',
@@ -2938,7 +2938,7 @@ class UploadFileMixin(
         parser.add_argument(
             '--content-language',
             help=
-            "optional Content-Language header, value based on RFC 2616 section 14.12, example: 'mi, EN_US'"
+            "optional Content-Language header, value based on RFC 2616 section 14.12, example: 'mi, en'"
         )
         parser.add_argument(
             '--expires',

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1054,19 +1054,29 @@ class CopyFileById(
         parser.add_argument('--contentType')
         parser.add_argument('--range', type=parse_range)
         parser.add_argument(
-            '--cache-control', help="optional Cache-Control header, value based on RFC 2616 section 14.9, example: 'public, max-age=86400')"
+            '--cache-control',
+            help=
+            "optional Cache-Control header, value based on RFC 2616 section 14.9, example: 'public, max-age=86400')"
         )
         parser.add_argument(
-            '--content-disposition', help="optional Content-Disposition header, value based on RFC 2616 section 19.5.1, example: 'attachment; filename=\"fname.ext\"'"
+            '--content-disposition',
+            help=
+            "optional Content-Disposition header, value based on RFC 2616 section 19.5.1, example: 'attachment; filename=\"fname.ext\"'"
         )
         parser.add_argument(
-            '--content-encoding', help="optional Content-Encoding header, value based on RFC 2616 section 14.11, example: 'gzip'"
+            '--content-encoding',
+            help=
+            "optional Content-Encoding header, value based on RFC 2616 section 14.11, example: 'gzip'"
         )
         parser.add_argument(
-            '--content-language', help="optional Content-Language header, value based on RFC 2616 section 14.12, example: 'mi, EN_US'"
+            '--content-language',
+            help=
+            "optional Content-Language header, value based on RFC 2616 section 14.12, example: 'mi, EN_US'"
         )
         parser.add_argument(
-            '--expires', help="optional Expires header, value based on RFC 2616 section 14.21, example: 'Thu, 01 Dec 2050 16:00:00 GMT'"
+            '--expires',
+            help=
+            "optional Expires header, value based on RFC 2616 section 14.21, example: 'Thu, 01 Dec 2050 16:00:00 GMT'"
         )
 
         info_group = parser.add_mutually_exclusive_group()
@@ -2911,19 +2921,29 @@ class UploadFileMixin(
             '--sha1', help="SHA-1 of the data being uploaded for verifying file integrity"
         )
         parser.add_argument(
-            '--cache-control', help="optional Cache-Control header, value based on RFC 2616 section 14.9, example: 'public, max-age=86400')"
+            '--cache-control',
+            help=
+            "optional Cache-Control header, value based on RFC 2616 section 14.9, example: 'public, max-age=86400')"
         )
         parser.add_argument(
-            '--content-disposition', help="optional Content-Disposition header, value based on RFC 2616 section 19.5.1, example: 'attachment; filename=\"fname.ext\"'"
+            '--content-disposition',
+            help=
+            "optional Content-Disposition header, value based on RFC 2616 section 19.5.1, example: 'attachment; filename=\"fname.ext\"'"
         )
         parser.add_argument(
-            '--content-encoding', help="optional Content-Encoding header, value based on RFC 2616 section 14.11, example: 'gzip'"
+            '--content-encoding',
+            help=
+            "optional Content-Encoding header, value based on RFC 2616 section 14.11, example: 'gzip'"
         )
         parser.add_argument(
-            '--content-language', help="optional Content-Language header, value based on RFC 2616 section 14.12, example: 'mi, EN_US'"
+            '--content-language',
+            help=
+            "optional Content-Language header, value based on RFC 2616 section 14.12, example: 'mi, EN_US'"
         )
         parser.add_argument(
-            '--expires', help="optional Expires header, value based on RFC 2616 section 14.21, example: 'Thu, 01 Dec 2050 16:00:00 GMT'"
+            '--expires',
+            help=
+            "optional Expires header, value based on RFC 2616 section 14.21, example: 'Thu, 01 Dec 2050 16:00:00 GMT'"
         )
         parser.add_argument(
             '--info',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete>=2,<4
 arrow>=1.0.2,<2.0.0
-b2sdk>=1.25.0,<2
+b2sdk @ git+https://github.com/Backblaze/b2-sdk-python@c0507d1b54e376ad5206ab253b028963d4cc5bdc
 docutils>=0.18.1
 idna~=3.4; platform_system == 'Java'
 importlib-metadata~=3.3; python_version < '3.8'

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -2691,7 +2691,9 @@ def test_cat(b2_tool, bucket_name, sample_filepath, tmp_path, uploaded_sample_fi
     assert b2_tool.should_succeed(['cat', f"b2id://{uploaded_sample_file['fileId']}"
                                   ],).replace("\r", "") == sample_filepath.read_text()
 
+
 def test_header_arguments(b2_tool, bucket_name, sample_filepath, tmp_path):
+    # yapf: disable
     args = [
         '--cache-control', 'max-age=3600',
         '--content-disposition', 'attachment',
@@ -2699,6 +2701,7 @@ def test_header_arguments(b2_tool, bucket_name, sample_filepath, tmp_path):
         '--content-language', 'en',
         '--expires', 'Thu, 01 Dec 2050 16:00:00 GMT',
     ]
+    # yapf: enable
     expected_file_info = {
         'b2-cache-control': 'max-age=3600',
         'b2-content-disposition': 'attachment',
@@ -2706,35 +2709,35 @@ def test_header_arguments(b2_tool, bucket_name, sample_filepath, tmp_path):
         'b2-content-language': 'en',
         'b2-expires': 'Thu, 01 Dec 2050 16:00:00 GMT',
     }
+
     def assert_expected(file_info, expected=expected_file_info):
         for key, val in expected.items():
             assert file_info[key] == val
 
-    file_version = b2_tool.should_succeed_json([
-        'upload-file',
-        '--quiet',
-        '--noProgress',
-        bucket_name,
-        str(sample_filepath),
-        'sample_file',
-        *args,
-    ])
+    file_version = b2_tool.should_succeed_json(
+        [
+            'upload-file',
+            '--quiet',
+            '--noProgress',
+            bucket_name,
+            str(sample_filepath),
+            'sample_file',
+            *args,
+        ]
+    )
     assert_expected(file_version['fileInfo'])
 
-    copied_version = b2_tool.should_succeed_json([
-        'copy-file-by-id',
-        '--quiet',
-        *args,
-        '--contentType', 'text/plain',
-        file_version['fileId'],
-        bucket_name,
-        'copied_file'
-    ])
+    copied_version = b2_tool.should_succeed_json(
+        [
+            'copy-file-by-id', '--quiet', *args, '--contentType', 'text/plain',
+            file_version['fileId'], bucket_name, 'copied_file'
+        ]
+    )
     assert_expected(copied_version['fileInfo'])
 
-    download_output = b2_tool.should_succeed([
-        'download-file-by-id', file_version['fileId'], tmp_path / 'downloaded_file'
-    ])
+    download_output = b2_tool.should_succeed(
+        ['download-file-by-id', file_version['fileId'], tmp_path / 'downloaded_file']
+    )
     assert re.search(r'CacheControl: *max-age=3600', download_output)
     assert re.search(r'ContentDisposition: *attachment', download_output)
     assert re.search(r'ContentEncoding: *gzip', download_output)

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -2690,3 +2690,53 @@ def test_cat(b2_tool, bucket_name, sample_filepath, tmp_path, uploaded_sample_fi
     ).replace("\r", "") == sample_filepath.read_text()
     assert b2_tool.should_succeed(['cat', f"b2id://{uploaded_sample_file['fileId']}"
                                   ],).replace("\r", "") == sample_filepath.read_text()
+
+def test_header_arguments(b2_tool, bucket_name, sample_filepath, tmp_path):
+    args = [
+        '--cache-control', 'max-age=3600',
+        '--content-disposition', 'attachment',
+        '--content-encoding', 'gzip',
+        '--content-language', 'en',
+        '--expires', 'Thu, 01 Dec 2050 16:00:00 GMT',
+    ]
+    expected_file_info = {
+        'b2-cache-control': 'max-age=3600',
+        'b2-content-disposition': 'attachment',
+        'b2-content-encoding': 'gzip',
+        'b2-content-language': 'en',
+        'b2-expires': 'Thu, 01 Dec 2050 16:00:00 GMT',
+    }
+    def assert_expected(file_info, expected=expected_file_info):
+        for key, val in expected.items():
+            assert file_info[key] == val
+
+    file_version = b2_tool.should_succeed_json([
+        'upload-file',
+        '--quiet',
+        '--noProgress',
+        bucket_name,
+        str(sample_filepath),
+        'sample_file',
+        *args,
+    ])
+    assert_expected(file_version['fileInfo'])
+
+    copied_version = b2_tool.should_succeed_json([
+        'copy-file-by-id',
+        '--quiet',
+        *args,
+        '--contentType', 'text/plain',
+        file_version['fileId'],
+        bucket_name,
+        'copied_file'
+    ])
+    assert_expected(copied_version['fileInfo'])
+
+    download_output = b2_tool.should_succeed([
+        'download-file-by-id', file_version['fileId'], tmp_path / 'downloaded_file'
+    ])
+    assert re.search(r'CacheControl: *max-age=3600', download_output)
+    assert re.search(r'ContentDisposition: *attachment', download_output)
+    assert re.search(r'ContentEncoding: *gzip', download_output)
+    assert re.search(r'ContentLanguage: *en', download_output)
+    assert re.search(r'Expires: *Thu, 01 Dec 2050 16:00:00 GMT', download_output)

--- a/test/unit/console_tool/test_upload_file.py
+++ b/test/unit/console_tool/test_upload_file.py
@@ -13,7 +13,7 @@ from test.helpers import skip_on_windows
 import b2
 
 
-def test_upload_file__file_info_src_last_modified_millis(b2_cli, bucket, tmpdir):
+def test_upload_file__file_info_src_last_modified_millis_and_headers(b2_cli, bucket, tmpdir):
     """Test upload_file supports manually specifying file info src_last_modified_millis"""
     filename = 'file1.txt'
     content = 'hello world'
@@ -24,6 +24,11 @@ def test_upload_file__file_info_src_last_modified_millis(b2_cli, bucket, tmpdir)
         "action": "upload",
         "contentSha1": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
         "fileInfo": {
+            "b2-cache-control": "max-age=3600",
+            "b2-expires": "Thu, 01 Dec 2050 16:00:00 GMT",
+            "b2-content-language": "en",
+            "b2-content-disposition": "attachment",
+            "b2-content-encoding": "gzip",
             "src_last_modified_millis": "1"
         },
         "fileName": filename,
@@ -32,6 +37,9 @@ def test_upload_file__file_info_src_last_modified_millis(b2_cli, bucket, tmpdir)
     b2_cli.run(
         [
             'upload-file', '--noProgress', '--info=src_last_modified_millis=1', 'my-bucket',
+            '--cache-control', 'max-age=3600', '--expires', 'Thu, 01 Dec 2050 16:00:00 GMT',
+            '--content-language', 'en', '--content-disposition', 'attachment',
+            '--content-encoding', 'gzip',
             str(local_file1), 'file1.txt'
         ],
         expected_json_in_stdout=expected_json,

--- a/test/unit/console_tool/test_upload_file.py
+++ b/test/unit/console_tool/test_upload_file.py
@@ -23,14 +23,15 @@ def test_upload_file__file_info_src_last_modified_millis_and_headers(b2_cli, buc
     expected_json = {
         "action": "upload",
         "contentSha1": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
-        "fileInfo": {
-            "b2-cache-control": "max-age=3600",
-            "b2-expires": "Thu, 01 Dec 2050 16:00:00 GMT",
-            "b2-content-language": "en",
-            "b2-content-disposition": "attachment",
-            "b2-content-encoding": "gzip",
-            "src_last_modified_millis": "1"
-        },
+        "fileInfo":
+            {
+                "b2-cache-control": "max-age=3600",
+                "b2-expires": "Thu, 01 Dec 2050 16:00:00 GMT",
+                "b2-content-language": "en",
+                "b2-content-disposition": "attachment",
+                "b2-content-encoding": "gzip",
+                "src_last_modified_millis": "1"
+            },
         "fileName": filename,
         "size": len(content),
     }
@@ -38,8 +39,8 @@ def test_upload_file__file_info_src_last_modified_millis_and_headers(b2_cli, buc
         [
             'upload-file', '--noProgress', '--info=src_last_modified_millis=1', 'my-bucket',
             '--cache-control', 'max-age=3600', '--expires', 'Thu, 01 Dec 2050 16:00:00 GMT',
-            '--content-language', 'en', '--content-disposition', 'attachment',
-            '--content-encoding', 'gzip',
+            '--content-language', 'en', '--content-disposition', 'attachment', '--content-encoding',
+            'gzip',
             str(local_file1), 'file1.txt'
         ],
         expected_json_in_stdout=expected_json,


### PR DESCRIPTION
Adds `--expires`, `--content-disposition`, `--content-encoding`, `--content-language` options to subcommands `upload-file`, `upload-unbound-stream`, `copy-file-by-id`.

It used as-of-yet unreleased b2sdk version, hence the draft PR.