### PR TITLE
fix Markdown formatting

### DIFF
--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -767,10 +767,12 @@ class B2(Command):
     The location of this database is determined in the following way:
 
     If ``--profile`` arg is provided:
+
     * ``{XDG_CONFIG_HOME_ENV_VAR}/b2/db-<profile>.sqlite``, if ``{XDG_CONFIG_HOME_ENV_VAR}`` env var is set
     * ``{B2_ACCOUNT_INFO_PROFILE_FILE}``
 
     Otherwise:
+
     * ``{B2_ACCOUNT_INFO_ENV_VAR}`` env var's value, if set
     * ``{B2_ACCOUNT_INFO_DEFAULT_FILE}``, if it exists
     * ``{XDG_CONFIG_HOME_ENV_VAR}/b2/account_info``, if ``{XDG_CONFIG_HOME_ENV_VAR}`` env var is set

--- a/changelog.d/+fix-list-formatting.doc.md
+++ b/changelog.d/+fix-list-formatting.doc.md
@@ -1,0 +1,1 @@
+Add additional linebreaks to ensure lists are properly rendered.


### PR DESCRIPTION
Lists are not properly rendered without the additional linebreak, cf. https://b2-command-line-tool.readthedocs.io/en/v3.13.1/#overview