### PR TITLE
B2 URI commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ The `changelog.d` file name convention is:
 
 These files can either be created manually, or using `towncrier` e.g.
 
-    towncrier create -c 'write your description here' 157.fixed.md
+    towncrier create -c 'Add proper changelog example to CONTRIBUTING guide' 157.added.md
 
 `towncrier create` also takes care of duplicates automatically (if there is more than 1 news fragment of one type 
 for a given github issue).

--- a/README.md
+++ b/README.md
@@ -74,12 +74,11 @@ b2 create-key [-h] [--bucket BUCKET] [--namePrefix NAMEPREFIX] [--duration DURAT
 b2 delete-bucket [-h] bucketName
 b2 delete-file-version [-h] [--bypassGovernance] [fileName] fileId
 b2 delete-key [-h] applicationKeyId
-b2 download-file-by-id [-h] [--threads THREADS] [--noProgress] [--sourceServerSideEncryption {SSE-C}] [--sourceServerSideEncryptionAlgorithm {AES256}] [--write-buffer-size BYTES] [--skip-hash-verification] [--max-download-streams-per-file MAX_DOWNLOAD_STREAMS_PER_FILE] fileId localFileName
-b2 download-file-by-name [-h] [--threads THREADS] [--noProgress] [--sourceServerSideEncryption {SSE-C}] [--sourceServerSideEncryptionAlgorithm {AES256}] [--write-buffer-size BYTES] [--skip-hash-verification] [--max-download-streams-per-file MAX_DOWNLOAD_STREAMS_PER_FILE] bucketName b2FileName localFileName
-b2 cat [-h] [--noProgress] [--sourceServerSideEncryption {SSE-C}] [--sourceServerSideEncryptionAlgorithm {AES256}] [--write-buffer-size BYTES] [--skip-hash-verification] b2uri
+b2 download-file [-h] [--threads THREADS] [--max-download-streams-per-file MAX_DOWNLOAD_STREAMS_PER_FILE] [--noProgress] [--sourceServerSideEncryption {SSE-C}] [--sourceServerSideEncryptionAlgorithm {AES256}] [--write-buffer-size BYTES] [--skip-hash-verification] B2_URI localFileName
+b2 cat [-h] [--noProgress] [--sourceServerSideEncryption {SSE-C}] [--sourceServerSideEncryptionAlgorithm {AES256}] [--write-buffer-size BYTES] [--skip-hash-verification] B2_URI
 b2 get-account-info [-h]
 b2 get-bucket [-h] [--showSize] bucketName
-b2 get-file-info [-h] fileId
+b2 file-info [-h] B2_URI
 b2 get-download-auth [-h] [--prefix PREFIX] [--duration DURATION] bucketName
 b2 get-download-url-with-auth [-h] [--duration DURATION] bucketName fileName
 b2 hide-file [-h] bucketName fileName
@@ -89,8 +88,7 @@ b2 list-parts [-h] largeFileId
 b2 list-unfinished-large-files [-h] bucketName
 b2 ls [-h] [--long] [--json] [--replication] [--versions] [-r] [--withWildcard] bucketName [folderName]
 b2 rm [-h] [--dryRun] [--queueSize QUEUESIZE] [--noProgress] [--failFast] [--threads THREADS] [--versions] [-r] [--withWildcard] bucketName [folderName]
-b2 make-url [-h] fileId
-b2 make-friendly-url [-h] bucketName fileName
+b2 get-url [-h] B2_URI
 b2 sync [-h] [--noProgress] [--dryRun] [--allowEmptySource] [--excludeAllSymlinks] [--syncThreads SYNCTHREADS] [--downloadThreads DOWNLOADTHREADS] [--uploadThreads UPLOADTHREADS] [--compareVersions {none,modTime,size}] [--compareThreshold MILLIS] [--excludeRegex REGEX] [--includeRegex REGEX] [--excludeDirRegex REGEX] [--excludeIfModifiedAfter TIMESTAMP] [--threads THREADS] [--destinationServerSideEncryption {SSE-B2,SSE-C}] [--destinationServerSideEncryptionAlgorithm {AES256}] [--sourceServerSideEncryption {SSE-C}] [--sourceServerSideEncryptionAlgorithm {AES256}] [--write-buffer-size BYTES] [--skip-hash-verification] [--max-download-streams-per-file MAX_DOWNLOAD_STREAMS_PER_FILE] [--incrementalMode] [--skipNewer | --replaceNewer] [--delete | --keepDays DAYS] source destination
 b2 update-bucket [-h] [--bucketInfo BUCKETINFO] [--corsRules CORSRULES] [--defaultRetentionMode {compliance,governance,none}] [--defaultRetentionPeriod period] [--replication REPLICATION] [--fileLockEnabled] [--defaultServerSideEncryption {SSE-B2,none}] [--defaultServerSideEncryptionAlgorithm {AES256}] [--lifecycleRule LIFECYCLERULES | --lifecycleRules LIFECYCLERULES] bucketName [{allPublic,allPrivate}]
 b2 upload-file [-h] [--contentType CONTENTTYPE] [--sha1 SHA1] [--cache-control CACHE_CONTROL] [--info INFO] [--custom-upload-timestamp CUSTOM_UPLOAD_TIMESTAMP] [--minPartSize MINPARTSIZE] [--threads THREADS] [--noProgress] [--destinationServerSideEncryption {SSE-B2,SSE-C}] [--destinationServerSideEncryptionAlgorithm {AES256}] [--legalHold {on,off}] [--fileRetentionMode {compliance,governance}] [--retainUntil TIMESTAMP] [--incrementalMode] bucketName localFilePath b2FileName

--- a/b2/_cli/argcompleters.py
+++ b/b2/_cli/argcompleters.py
@@ -57,7 +57,7 @@ def file_name_completer(api: B2Api, parsed_args, **kwargs):
 @_with_api
 def b2uri_file_completer(api: B2Api, prefix: str, **kwargs):
     """
-    Completes B2 URI pointing to a file-like object in a bucket.
+    Complete B2 URI pointing to a file-like object in a bucket.
     """
     if prefix.startswith('b2://'):
         prefix_without_scheme = removeprefix(prefix, 'b2://')

--- a/b2/_cli/b2args.py
+++ b/b2/_cli/b2args.py
@@ -1,0 +1,44 @@
+######################################################################
+#
+# File: b2/_cli/b2args.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+"""
+Utility functions for adding b2-specific arguments to an argparse parser.
+"""
+import argparse
+
+from b2._cli.argcompleters import b2uri_file_completer
+from b2._utils.uri import B2URI, B2URIBase, parse_b2_uri
+from b2.arg_parser import wrap_with_argument_type_error
+
+
+def b2_file_uri(value: str) -> B2URIBase:
+    b2_uri = parse_b2_uri(value)
+    if isinstance(b2_uri, B2URI):
+        if b2_uri.is_dir():
+            raise ValueError(
+                f"B2 URI pointing to a file-like object is required, but {value} was provided"
+            )
+        return b2_uri
+
+    return b2_uri
+
+
+B2_URI_ARG_TYPE = wrap_with_argument_type_error(parse_b2_uri)
+B2_URI_FILE_ARG_TYPE = wrap_with_argument_type_error(b2_file_uri)
+
+
+def add_b2_file_argument(parser: argparse.ArgumentParser, name="B2_URI"):
+    """
+    Add an argument to the parser that must be a B2 URI pointing to a file.
+    """
+    parser.add_argument(
+        name,
+        type=B2_URI_FILE_ARG_TYPE,
+        help="B2 URI pointing to a file, e.g. b2://yourBucket/file.txt or b2id://fileId",
+    ).completer = b2uri_file_completer

--- a/b2/_cli/b2args.py
+++ b/b2/_cli/b2args.py
@@ -35,7 +35,7 @@ B2_URI_FILE_ARG_TYPE = wrap_with_argument_type_error(b2_file_uri)
 
 def add_b2_file_argument(parser: argparse.ArgumentParser, name="B2_URI"):
     """
-    Add an argument to the parser that must be a B2 URI pointing to a file.
+    Add a B2 URI pointing to a file as an argument to the parser.
     """
     parser.add_argument(
         name,

--- a/b2/_utils/python_compat.py
+++ b/b2/_utils/python_compat.py
@@ -1,0 +1,49 @@
+######################################################################
+#
+# File: b2/_utils/python_compat.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+"""
+Utilities for compatibility with older Python versions.
+"""
+import functools
+import sys
+
+if sys.version_info < (3, 9):
+
+    def removeprefix(s: str, prefix: str) -> str:
+        return s[len(prefix):] if s.startswith(prefix) else s
+
+else:
+    removeprefix = str.removeprefix
+
+if sys.version_info < (3, 8):
+
+    class singledispatchmethod:
+        """
+        singledispatchmethod backport for Python 3.7.
+
+        There are no guarantees for its completeness.
+        """
+
+        def __init__(self, method):
+            self.dispatcher = functools.singledispatch(method)
+            self.method = method
+
+        def register(self, cls, method=None):
+            return self.dispatcher.register(cls, func=method)
+
+        def __get__(self, obj, cls):
+            @functools.wraps(self.method)
+            def method_wrapper(arg, *args, **kwargs):
+                method_desc = self.dispatcher.dispatch(arg.__class__)
+                return method_desc.__get__(obj, cls)(arg, *args, **kwargs)
+
+            method_wrapper.register = self.register
+            return method_wrapper
+else:
+    singledispatchmethod = functools.singledispatchmethod

--- a/b2/_utils/uri.py
+++ b/b2/_utils/uri.py
@@ -14,22 +14,65 @@ import pathlib
 import urllib
 from pathlib import Path
 
+from b2sdk.v2 import (
+    B2Api,
+    DownloadVersion,
+    FileVersion,
+)
+
+from b2._utils.python_compat import removeprefix, singledispatchmethod
+
 
 class B2URIBase:
     pass
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class B2URI(B2URIBase):
-    bucket: str
-    path: str
+    """
+    B2 URI designating a particular object by name & bucket or "subdirectory" in a bucket.
+
+    Please note, both files and directories are symbolical concept, not a real one in B2, i.e.
+    there is no such thing as "directory" in B2, but it is possible to mimic it by using object names with non-trailing
+    slashes.
+    To make it possible, it is highly discouraged to use trailing slashes in object names.
+    """
+
+    bucket_name: str
+    path: str = ""
+
+    def __post_init__(self):
+        path = removeprefix(self.path, "/")
+        self.__dict__["path"] = path  # hack for a custom init in frozen dataclass
 
     def __str__(self) -> str:
-        return f"b2://{self.bucket}{self.path}"
+        return f"b2://{self.bucket_name}/{self.path}"
+
+    def is_dir(self) -> bool | None:
+        """
+        Return if the path is a directory.
+
+        Please note this is symbolical.
+        It is possible for file to have a trailing slash, but it is HIGHLY discouraged, and not supported by B2 CLI.
+        At the same time it is possible for a directory to not have a trailing slash,
+        which is discouraged, but allowed by B2 CLI.
+        This is done to mimic unix-like Path.
+
+        In practice, this means that `.is_dir() == True` will always be interpreted as "this is a directory",
+        but reverse is not necessary true, and `not uri.is_dir()` should be merely interpreted as
+        "this is a directory or a file".
+
+        :return: True if the path is a directory, None if it is unknown
+        """
+        return not self.path or self.path.endswith("/") or None
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class B2FileIdURI(B2URIBase):
+    """
+    B2 URI designating a particular file by its id.
+    """
+
     file_id: str
 
     def __str__(self) -> str:
@@ -58,8 +101,62 @@ def _parse_b2_uri(uri, parsed: urllib.parse.ParseResult) -> B2URI | B2FileIdURI:
             )
 
         if parsed.scheme == "b2":
-            return B2URI(bucket=parsed.netloc, path=parsed.path[1:])
+            return B2URI(bucket_name=parsed.netloc, path=parsed.path)
         elif parsed.scheme == "b2id":
-            return B2FileIdURI(file_id=parsed.netloc)
+            file_id = parsed.netloc
+            if not file_id:
+                raise ValueError(f"File id was not provided in B2 URI: {uri!r}")
+            return B2FileIdURI(file_id=file_id)
     else:
         raise ValueError(f"Unsupported URI scheme: {parsed.scheme!r}")
+
+
+class B2URIAdapter:
+    """
+    Adapter for using B2URI with B2Api.
+
+    When this matures enough methods from here should be moved to b2sdk B2Api class.
+    """
+
+    def __init__(self, api: B2Api):
+        self.api = api
+
+    def __getattr__(self, name):
+        return getattr(self.api, name)
+
+    @singledispatchmethod
+    def download_file_by_uri(self, uri, *args, **kwargs):
+        raise NotImplementedError(f"Unsupported URI type: {type(uri)}")
+
+    @download_file_by_uri.register
+    def _(self, uri: B2URI, *args, **kwargs):
+        bucket = self.get_bucket_by_name(uri.bucket_name)
+        return bucket.download_file_by_name(uri.path, *args, **kwargs)
+
+    @download_file_by_uri.register
+    def _(self, uri: B2FileIdURI, *args, **kwargs):
+        return self.download_file_by_id(uri.file_id, *args, **kwargs)
+
+    @singledispatchmethod
+    def get_file_info_by_uri(self, uri, *args, **kwargs):
+        raise NotImplementedError(f"Unsupported URI type: {type(uri)}")
+
+    @get_file_info_by_uri.register
+    def _(self, uri: B2URI, *args, **kwargs) -> DownloadVersion:
+        return self.get_file_info_by_name(uri.bucket_name, uri.path, *args, **kwargs)
+
+    @get_file_info_by_uri.register
+    def _(self, uri: B2FileIdURI, *args, **kwargs) -> FileVersion:
+        return self.get_file_info(uri.file_id, *args, **kwargs)
+
+    @singledispatchmethod
+    def get_download_url_by_uri(self, uri, *args, **kwargs):
+        raise NotImplementedError(f"Unsupported URI type: {type(uri)}")
+
+    @get_download_url_by_uri.register
+    def _(self, uri: B2URI, *args, **kwargs) -> str:
+        return self.get_download_url_for_file_name(uri.bucket_name, uri.path, *args, **kwargs)
+
+    @get_download_url_by_uri.register
+    def _(self, uri: B2FileIdURI, *args, **kwargs) -> str:
+        return self.get_download_url_for_fileid(uri.file_id, *args, **kwargs)

--- a/b2/arg_parser.py
+++ b/b2/arg_parser.py
@@ -7,6 +7,7 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+from __future__ import annotations
 
 import argparse
 import functools
@@ -22,11 +23,11 @@ from rst2ansi import rst2ansi
 _arrow_version = tuple(int(p) for p in arrow.__version__.split("."))
 
 
-class RawTextHelpFormatter(argparse.RawTextHelpFormatter):
+class B2RawTextHelpFormatter(argparse.RawTextHelpFormatter):
     """
     CLI custom formatter.
 
-    It removes default "usage: " text and prints usage for all subcommands.
+    It removes default "usage: " text and prints usage for all (non-hidden) subcommands.
     """
 
     def add_usage(self, usage, actions, groups, prefix=None):
@@ -38,7 +39,8 @@ class RawTextHelpFormatter(argparse.RawTextHelpFormatter):
         if isinstance(action, argparse._SubParsersAction) and action.help is not argparse.SUPPRESS:
             usages = []
             for choice in self._unique_choice_values(action):
-                usages.append(choice.format_usage())
+                if not getattr(choice, 'hidden', False):
+                    usages.append(choice.format_usage())
             self.add_text(''.join(usages))
         else:
             super().add_argument(action)
@@ -52,7 +54,7 @@ class RawTextHelpFormatter(argparse.RawTextHelpFormatter):
                 yield value
 
 
-class ArgumentParser(argparse.ArgumentParser):
+class B2ArgumentParser(argparse.ArgumentParser):
     """
     CLI custom parser.
 
@@ -60,11 +62,17 @@ class ArgumentParser(argparse.ArgumentParser):
     and use help message in case of error.
     """
 
-    def __init__(self, *args, for_docs=False, **kwargs):
+    def __init__(self, *args, for_docs: bool = False, hidden: bool = False, **kwargs):
+        """
+
+        :param for_docs: is this parser used for generating docs
+        :param hidden: should this parser be hidden from `--help`
+        """
         self._raw_description = None
         self._description = None
         self._for_docs = for_docs
-        kwargs.setdefault('formatter_class', RawTextHelpFormatter)
+        self.hidden = hidden
+        kwargs.setdefault('formatter_class', B2RawTextHelpFormatter)
         super().__init__(*args, **kwargs)
 
     @property

--- a/b2/json_encoder.py
+++ b/b2/json_encoder.py
@@ -11,7 +11,7 @@
 import json
 from enum import Enum
 
-from b2sdk.v2 import Bucket, FileIdAndName, FileVersion
+from b2sdk.v2 import Bucket, DownloadVersion, FileIdAndName, FileVersion
 
 
 class B2CliJsonEncoder(json.JSONEncoder):
@@ -27,7 +27,7 @@ class B2CliJsonEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, set):
             return list(obj)
-        elif isinstance(obj, (FileVersion, FileIdAndName, Bucket)):
+        elif isinstance(obj, (DownloadVersion, FileVersion, FileIdAndName, Bucket)):
             return obj.as_dict()
         elif isinstance(obj, Enum):
             return obj.value

--- a/changelog.d/+b2_uri_cmds.added.md
+++ b/changelog.d/+b2_uri_cmds.added.md
@@ -1,0 +1,1 @@
+Add `download-file`, `file-info` and `get-url` commands using new B2 URI syntax allowing for referring to file-like objects by their bucket&name or ID.

--- a/changelog.d/+b2_uri_cmds.deprecated.md
+++ b/changelog.d/+b2_uri_cmds.deprecated.md
@@ -1,0 +1,3 @@
+Deprecated `download-file-by-id` and `download-file-by-name`, use `download-file` instead.
+Deprecated `get-file-info`, use `file-info` instead.
+Deprecated `make-url` and `make-friendly-url`, use `get-url` instead.

--- a/changelog.d/+cat.doc.md
+++ b/changelog.d/+cat.doc.md
@@ -1,0 +1,1 @@
+Add `cat` command to documentation

--- a/doc/source/subcommands/cat.rst
+++ b/doc/source/subcommands/cat.rst
@@ -1,0 +1,8 @@
+Cat command
+****************
+
+.. argparse::
+   :module: b2.console_tool
+   :func: get_parser
+   :prog: b2
+   :path: cat

--- a/doc/source/subcommands/download_file.rst
+++ b/doc/source/subcommands/download_file.rst
@@ -1,0 +1,8 @@
+Download-file command
+***************************
+
+.. argparse::
+   :module: b2.console_tool
+   :func: get_parser
+   :prog: b2
+   :path: download-file

--- a/doc/source/subcommands/file_info.rst
+++ b/doc/source/subcommands/file_info.rst
@@ -1,0 +1,8 @@
+File-info command
+*********************
+
+.. argparse::
+   :module: b2.console_tool
+   :func: get_parser
+   :prog: b2
+   :path: file-info

--- a/doc/source/subcommands/get_url.rst
+++ b/doc/source/subcommands/get_url.rst
@@ -1,0 +1,8 @@
+Get-url command
+****************
+
+.. argparse::
+   :module: b2.console_tool
+   :func: get_parser
+   :prog: b2
+   :path: get-url

--- a/test/integration/test_autocomplete.py
+++ b/test/integration/test_autocomplete.py
@@ -60,7 +60,7 @@ def test_autocomplete_b2_commands(autocomplete_installed, is_running_on_docker, 
     if is_running_on_docker:
         pytest.skip('Not supported on Docker')
     shell.send('b2 \t\t')
-    shell.expect_exact(["authorize-account", "download-file-by-id", "get-bucket"], timeout=TIMEOUT)
+    shell.expect_exact(["authorize-account", "download-file", "get-bucket"], timeout=TIMEOUT)
 
 
 @skip_on_windows
@@ -69,26 +69,11 @@ def test_autocomplete_b2_only_matching_commands(
 ):
     if is_running_on_docker:
         pytest.skip('Not supported on Docker')
-    shell.send('b2 download-\t\t')
+    shell.send('b2 delete-\t\t')
 
-    shell.expect_exact(
-        "file-by-", timeout=TIMEOUT
-    )  # common part of remaining cmds is autocompleted
+    shell.expect_exact("file", timeout=TIMEOUT)  # common part of remaining cmds is autocompleted
     with pytest.raises(pexpect.exceptions.TIMEOUT):  # no other commands are suggested
         shell.expect_exact("get-bucket", timeout=0.5)
-
-
-@skip_on_windows
-def test_autocomplete_b2_bucket_n_file_name(
-    autocomplete_installed, shell, b2_tool, bucket_name, file_name, is_running_on_docker
-):
-    """Test that autocomplete suggests bucket names and file names."""
-    if is_running_on_docker:
-        pytest.skip('Not supported on Docker')
-    shell.send('b2 download_file_by_name \t\t')
-    shell.expect_exact(bucket_name, timeout=TIMEOUT)
-    shell.send(f'{bucket_name} \t\t')
-    shell.expect_exact(file_name, timeout=TIMEOUT)
 
 
 @skip_on_windows

--- a/test/integration/test_autocomplete.py
+++ b/test/integration/test_autocomplete.py
@@ -89,3 +89,18 @@ def test_autocomplete_b2_bucket_n_file_name(
     shell.expect_exact(bucket_name, timeout=TIMEOUT)
     shell.send(f'{bucket_name} \t\t')
     shell.expect_exact(file_name, timeout=TIMEOUT)
+
+
+@skip_on_windows
+def test_autocomplete_b2__download_file__b2uri(
+    autocomplete_installed, shell, b2_tool, bucket_name, file_name, is_running_on_docker
+):
+    """Test that autocomplete suggests bucket names and file names."""
+    if is_running_on_docker:
+        pytest.skip('Not supported on Docker')
+    shell.send('b2 download_file \t\t')
+    shell.expect_exact("b2://", timeout=TIMEOUT)
+    shell.send('b2://\t\t')
+    shell.expect_exact(bucket_name, timeout=TIMEOUT)
+    shell.send(f'{bucket_name}/\t\t')
+    shell.expect_exact(file_name, timeout=TIMEOUT)

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -176,7 +176,7 @@ def test_basic(b2_tool, bucket_name, sample_file, tmp_path):
     b2_tool.should_succeed(['ls', bucket_name, 'b'], '^b/1{0}b/2{0}'.format(os.linesep))
     b2_tool.should_succeed(['ls', bucket_name, 'b/'], '^b/1{0}b/2{0}'.format(os.linesep))
 
-    file_info = b2_tool.should_succeed_json(['get-file-info', second_c_version['fileId']])
+    file_info = b2_tool.should_succeed_json(['file-info', f"b2id://{second_c_version['fileId']}"])
     expected_info = {
         'color': 'blue',
         'foo': 'bar=baz',
@@ -187,10 +187,10 @@ def test_basic(b2_tool, bucket_name, sample_file, tmp_path):
     b2_tool.should_succeed(['delete-file-version', 'c', first_c_version['fileId']])
     b2_tool.should_succeed(['ls', bucket_name], '^a{0}b/{0}c{0}d{0}'.format(os.linesep))
 
-    b2_tool.should_succeed(['make-url', second_c_version['fileId']])
+    b2_tool.should_succeed(['get-url', f"b2id://{second_c_version['fileId']}"])
 
     b2_tool.should_succeed(
-        ['make-friendly-url', bucket_name, 'any-file-name'],
+        ['get-url', f"b2://{bucket_name}/any-file-name"],
         '^https://.*/file/{}/{}\r?$'.format(
             bucket_name,
             'any-file-name',

--- a/test/unit/console_tool/conftest.py
+++ b/test/unit/console_tool/conftest.py
@@ -37,10 +37,19 @@ def authorized_b2_cli(b2_cli):
 
 
 @pytest.fixture
-def bucket(b2_cli, authorized_b2_cli):
+def bucket_info(b2_cli, authorized_b2_cli):
     bucket_name = "my-bucket"
-    b2_cli.run(['create-bucket', bucket_name, 'allPublic'], expected_stdout='bucket_0\n')
-    yield bucket_name
+    bucket_id = "bucket_0"
+    b2_cli.run(['create-bucket', bucket_name, 'allPublic'], expected_stdout=f'{bucket_id}\n')
+    return {
+        'bucketName': bucket_name,
+        'bucketId': bucket_id,
+    }
+
+
+@pytest.fixture
+def bucket(bucket_info):
+    return bucket_info['bucketName']
 
 
 @pytest.fixture
@@ -50,3 +59,30 @@ def mock_stdin(monkeypatch):
     in_f = open(in_, 'w')
     yield in_f
     in_f.close()
+
+
+@pytest.fixture
+def local_file(tmp_path):
+    """Set up a test file and return its path."""
+    filename = 'file1.txt'
+    content = 'hello world'
+    local_file = tmp_path / filename
+    local_file.write_text(content)
+
+    mod_time = 1500111222
+    os.utime(local_file, (mod_time, mod_time))
+
+    return local_file
+
+
+@pytest.fixture
+def uploaded_file(b2_cli, bucket_info, local_file):
+    filename = 'file1.txt'
+    b2_cli.run(['upload-file', '--quiet', bucket_info["bucketName"], str(local_file), filename])
+    return {
+        'bucket': bucket_info["bucketName"],
+        'bucketId': bucket_info["bucketId"],
+        'fileName': filename,
+        'fileId': '9999',
+        'content': local_file.read_text(),
+    }

--- a/test/unit/console_tool/test_download_file.py
+++ b/test/unit/console_tool/test_download_file.py
@@ -73,7 +73,9 @@ def test_download_file_by_name(b2_cli, local_file, uploaded_file, tmp_path, flag
             'download-file-by-name', uploaded_file['bucket'], uploaded_file['fileName'],
             str(output_path)
         ],
-        expected_stdout=EXPECTED_STDOUT_DOWNLOAD
+        expected_stdout=EXPECTED_STDOUT_DOWNLOAD,
+        expected_stderr=
+        'WARNING: download-file-by-name command is deprecated. Use download-file instead.\n',
     )
     assert output_path.read_text() == uploaded_file['content']
 
@@ -89,7 +91,10 @@ def test_download_file_by_id(b2_cli, uploaded_file, tmp_path, flag, expected_std
     output_path = tmp_path / 'output.txt'
 
     b2_cli.run(
-        ['download-file-by-id', flag, '9999', str(output_path)], expected_stdout=expected_stdout
+        ['download-file-by-id', flag, '9999', str(output_path)],
+        expected_stdout=expected_stdout,
+        expected_stderr=
+        'WARNING: download-file-by-id command is deprecated. Use download-file instead.\n',
     )
     assert output_path.read_text() == uploaded_file['content']
 
@@ -115,7 +120,9 @@ def test_download_file_by_name__named_pipe(
             uploaded_file['fileName'],
             str(output_path)
         ],
-        expected_stdout=EXPECTED_STDOUT_DOWNLOAD
+        expected_stdout=EXPECTED_STDOUT_DOWNLOAD,
+        expected_stderr=
+        'WARNING: download-file-by-name command is deprecated. Use download-file instead.\n',
     )
     reader_future.result(timeout=1)
     assert output_string == uploaded_file['content']
@@ -138,6 +145,8 @@ def test_download_file_by_name__to_stdout_by_alias(
     """Test download_file_by_name stdout alias support"""
     b2_cli.run(
         ['download-file-by-name', '--noProgress', bucket, uploaded_stdout_txt['fileName'], '-'],
+        expected_stderr=
+        'WARNING: download-file-by-name command is deprecated. Use download-file instead.\n',
     )
     assert capfd.readouterr().out == uploaded_stdout_txt['content']
     assert not pathlib.Path('-').exists()

--- a/test/unit/console_tool/test_file_info.py
+++ b/test/unit/console_tool/test_file_info.py
@@ -42,6 +42,7 @@ def test_get_file_info(b2_cli, uploaded_file_version):
     b2_cli.run(
         ["get-file-info", uploaded_file_version["fileId"]],
         expected_json_in_stdout=uploaded_file_version,
+        expected_stderr='WARNING: get-file-info command is deprecated. Use file-info instead.\n',
     )
 
 

--- a/test/unit/console_tool/test_file_info.py
+++ b/test/unit/console_tool/test_file_info.py
@@ -1,0 +1,62 @@
+######################################################################
+#
+# File: test/unit/console_tool/test_file_info.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+import pytest
+
+
+@pytest.fixture
+def uploaded_download_version(b2_cli, bucket_info, uploaded_file):
+    return {
+        "contentSha1": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+        "contentType": "b2/x-auto",
+        "fileId": uploaded_file["fileId"],
+        "fileInfo": {
+            "src_last_modified_millis": "1500111222000"
+        },
+        "fileName": "file1.txt",
+        "serverSideEncryption": {
+            "mode": "none"
+        },
+        "size": 11,
+        "uploadTimestamp": 5000,
+    }
+
+
+@pytest.fixture
+def uploaded_file_version(b2_cli, bucket_info, uploaded_file, uploaded_download_version):
+    return {
+        **uploaded_download_version,
+        "accountId": b2_cli.account_id,
+        "action": "upload",
+        "bucketId": uploaded_file["bucketId"],
+    }
+
+
+def test_get_file_info(b2_cli, uploaded_file_version):
+    b2_cli.run(
+        ["get-file-info", uploaded_file_version["fileId"]],
+        expected_json_in_stdout=uploaded_file_version,
+    )
+
+
+def test_file_info__b2_uri(b2_cli, bucket, uploaded_download_version):
+    b2_cli.run(
+        [
+            "file-info",
+            f'b2://{bucket}/{uploaded_download_version["fileName"]}',
+        ],
+        expected_json_in_stdout=uploaded_download_version,
+    )
+
+
+def test_file_info__b2id_uri(b2_cli, uploaded_file_version):
+    b2_cli.run(
+        ["file-info", f'b2id://{uploaded_file_version["fileId"]}'],
+        expected_json_in_stdout=uploaded_file_version,
+    )

--- a/test/unit/console_tool/test_get_url.py
+++ b/test/unit/console_tool/test_get_url.py
@@ -24,6 +24,7 @@ def test_make_url(b2_cli, uploaded_file, uploaded_file_url_by_id):
     b2_cli.run(
         ["make-url", uploaded_file["fileId"]],
         expected_stdout=f"{uploaded_file_url_by_id}\n",
+        expected_stderr='WARNING: make-url command is deprecated. Use get-url instead.\n',
     )
 
 
@@ -31,6 +32,7 @@ def test_make_friendly_url(b2_cli, bucket, uploaded_file, uploaded_file_url):
     b2_cli.run(
         ["make-friendly-url", bucket, uploaded_file["fileName"]],
         expected_stdout=f"{uploaded_file_url}\n",
+        expected_stderr='WARNING: make-friendly-url command is deprecated. Use get-url instead.\n',
     )
 
 

--- a/test/unit/console_tool/test_get_url.py
+++ b/test/unit/console_tool/test_get_url.py
@@ -1,0 +1,51 @@
+######################################################################
+#
+# File: test/unit/console_tool/test_get_url.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+import pytest
+
+
+@pytest.fixture
+def uploaded_file_url(bucket_info, uploaded_file):
+    return f"http://download.example.com/file/{bucket_info['bucketName']}/{uploaded_file['fileName']}"
+
+
+@pytest.fixture
+def uploaded_file_url_by_id(uploaded_file):
+    return f"http://download.example.com/b2api/v2/b2_download_file_by_id?fileId={uploaded_file['fileId']}"
+
+
+def test_make_url(b2_cli, uploaded_file, uploaded_file_url_by_id):
+    b2_cli.run(
+        ["make-url", uploaded_file["fileId"]],
+        expected_stdout=f"{uploaded_file_url_by_id}\n",
+    )
+
+
+def test_make_friendly_url(b2_cli, bucket, uploaded_file, uploaded_file_url):
+    b2_cli.run(
+        ["make-friendly-url", bucket, uploaded_file["fileName"]],
+        expected_stdout=f"{uploaded_file_url}\n",
+    )
+
+
+def test_get_url__b2_uri(b2_cli, bucket, uploaded_file, uploaded_file_url):
+    b2_cli.run(
+        [
+            "get-url",
+            f'b2://{bucket}/{uploaded_file["fileName"]}',
+        ],
+        expected_stdout=f"{uploaded_file_url}\n",
+    )
+
+
+def test_get_url__b2id_uri(b2_cli, uploaded_file, uploaded_file_url_by_id):
+    b2_cli.run(
+        ["get-url", f'b2id://{uploaded_file["fileId"]}'],
+        expected_stdout=f"{uploaded_file_url_by_id}\n",
+    )

--- a/test/unit/console_tool/test_help.py
+++ b/test/unit/console_tool/test_help.py
@@ -1,0 +1,43 @@
+######################################################################
+#
+# File: test/unit/console_tool/test_help.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+import pytest
+
+
+@pytest.mark.parametrize(
+    "flag, included, excluded",
+    [
+        # --help shouldn't show deprecated commands
+        (
+            "--help",
+            [" b2 download-file ", "-h", "--help-all"],
+            [" download-file-by-name ", "(DEPRECATED)"],
+        ),
+        # --help-all should show deprecated commands, but marked as deprecated
+        (
+            "--help-all",
+            ["(DEPRECATED) b2 download-file-by-name ", "-h", "--help-all"],
+            [],
+        ),
+    ],
+)
+def test_help(b2_cli, flag, included, excluded, capsys):
+    b2_cli.run([flag], expected_stdout=None)
+
+    out = capsys.readouterr().out
+
+    found = set()
+    for i in included:
+        if i in out:
+            found.add(i)
+    for e in excluded:
+        if e in out:
+            found.add(e)
+    assert found.issuperset(included), f"expected {included!r} in {out!r}"
+    assert found.isdisjoint(excluded), f"expected {excluded!r} not in {out!r}"

--- a/test/unit/test_arg_parser.py
+++ b/test/unit/test_arg_parser.py
@@ -12,7 +12,7 @@ import argparse
 import sys
 
 from b2.arg_parser import (
-    ArgumentParser,
+    B2ArgumentParser,
     parse_comma_separated_list,
     parse_millis_from_float_timestamp,
     parse_range,
@@ -61,7 +61,7 @@ class TestNonUTF8TerminalSupport(TestBase):
         help_string = command_class.__doc__
 
         # create a parser with a help message that is based on the command_class.__doc__ string
-        parser = ArgumentParser(description=help_string)
+        parser = B2ArgumentParser(description=help_string)
 
         try:
             old_stdout = sys.stdout

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -927,7 +927,7 @@ class TestConsoleTool(BaseConsoleToolTest):
             }
 
             self._run_command(
-                ['get-file-info', '9999'],
+                ['file-info', 'b2id://9999'],
                 expected_json_in_stdout=expected_json,
             )
 
@@ -1074,7 +1074,7 @@ class TestConsoleTool(BaseConsoleToolTest):
             }
 
             self._run_command(
-                ['get-file-info', '9999'],
+                ['file-info', 'b2id://9999'],
                 expected_json_in_stdout=expected_json,
             )
 
@@ -1095,10 +1095,8 @@ class TestConsoleTool(BaseConsoleToolTest):
             '''
 
             self._run_command(
-                [
-                    'download-file-by-name', '--noProgress', 'my-bucket', 'file1.txt',
-                    local_download1
-                ], expected_stdout, '', 0
+                ['download-file', '--noProgress', 'b2://my-bucket/file1.txt', local_download1],
+                expected_stdout, '', 0
             )
             self.assertEqual(b'hello world', self._read_file(local_download1))
             self.assertEqual(mod_time, int(round(os.path.getmtime(local_download1))))
@@ -1106,7 +1104,7 @@ class TestConsoleTool(BaseConsoleToolTest):
             # Download file by ID.  (Same expected output as downloading by name)
             local_download2 = os.path.join(temp_dir, 'download2.txt')
             self._run_command(
-                ['download-file-by-id', '--noProgress', '9999', local_download2], expected_stdout,
+                ['download-file', '--noProgress', 'b2id://9999', local_download2], expected_stdout,
                 '', 0
             )
             self.assertEqual(b'hello world', self._read_file(local_download2))
@@ -1207,7 +1205,11 @@ class TestConsoleTool(BaseConsoleToolTest):
             command += ['9999'] if download_by == 'id' else ['my-bucket', 'file.txt']
             local_download = os.path.join(temp_dir, 'download.txt')
             command += [local_download]
-            self._run_command(command)
+            self._run_command(
+                command,
+                expected_stderr=
+                f'WARNING: download-file-by-{download_by} command is deprecated. Use download-file instead.\n'
+            )
             self.assertEqual(b'hello world', self._read_file(local_download))
 
     def test_download_by_id_1_thread(self):
@@ -1309,10 +1311,7 @@ class TestConsoleTool(BaseConsoleToolTest):
 
             local_download1 = os.path.join(temp_dir, 'file1_copy.txt')
             self._run_command(
-                [
-                    'download-file-by-name', '--noProgress', 'my-bucket', 'file1_copy.txt',
-                    local_download1
-                ]
+                ['download-file', '-q', 'b2://my-bucket/file1_copy.txt', local_download1]
             )
             self.assertEqual(b'lo wo', self._read_file(local_download1))
 
@@ -1568,10 +1567,9 @@ class TestConsoleTool(BaseConsoleToolTest):
             downloaded_path = pathlib.Path(temp_dir) / 'out.txt'
             self._run_command(
                 [
-                    'download-file-by-name',
-                    '--noProgress',
-                    'my-bucket',
-                    'test.txt',
+                    'download-file',
+                    '-q',
+                    'b2://my-bucket/test.txt',
                     str(downloaded_path),
                 ]
             )

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -101,7 +101,7 @@ class BaseConsoleToolTest(TestBase):
             return ''
 
         # Count the leading spaces
-        space_count = min(self._leading_spaces(line) for line in lines if line != '')
+        space_count = min((self._leading_spaces(line) for line in lines if line != ''), default=0)
 
         # Remove the leading spaces from each line, based on the line
         # with the fewest leading spaces


### PR DESCRIPTION
* Add `download-file`, `file-info` and `get-url` commands using new B2 URI syntax allowing for referring to file-like objects by their bucket&name or ID.
* Deprecated `download-file-by-id` and `download-file-by-name`, use `download-file` instead.
* Deprecated `get-file-info`, use `file-info` instead.
* Deprecated `make-url` and `make-friendly-url`, use `get-url` instead.

Deprecation means here that stderr WARNING will be printed for those commands upon use.