### PR TITLE
Change docker py312 + loosen platformdirs requirement

### DIFF
--- a/.github/workflows/push_docker.yml
+++ b/.github/workflows/push_docker.yml
@@ -11,7 +11,7 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       DOCKERHUB_USERNAME: secrets.DOCKERHUB_USERNAME
       DOCKERHUB_TOKEN: secrets.DOCKERHUB_TOKEN
-      PYTHON_DEFAULT_VERSION: 3.11
+      PYTHON_DEFAULT_VERSION: 3.12
     steps:
       - uses: actions/checkout@v3
         with:

--- a/changelog.d/+docker_py312.changed.md
+++ b/changelog.d/+docker_py312.changed.md
@@ -1,0 +1,1 @@
+Use Python 3.12 in the official `b2` Docker image.

--- a/changelog.d/+loosen_platformdirs.fixed.md
+++ b/changelog.d/+loosen_platformdirs.fixed.md
@@ -1,0 +1,1 @@
+Loosen platformdirs dependency version specifier.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ phx-class-registry~=4.0
 rst2ansi==0.1.5
 tabulate==0.9.0
 tqdm~=4.65.0
-platformdirs>=4.0.0,<5
+platformdirs>=3.11.0,<5


### PR DESCRIPTION
* fixes CD docker build fail https://github.com/Backblaze/B2_Command_Line_Tool/actions/runs/7119640521/job/19385199673
* it seems poetry requires just released platformdirs v3.11 - for us this makes no difference, so I loosened this requirement as it is pretty popular piece of software