### PR TITLE
Printing the output path for the downloaded object

### DIFF
--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1532,10 +1532,16 @@ class DownloadCommand(
 ):
     """ helper methods for returning results from download commands """
 
-    def _print_download_info(self, downloaded_file: DownloadedFile):
+    def _print_download_info(
+        self, downloaded_file: DownloadedFile, output_filepath: pathlib.Path
+    ) -> None:
         download_version = downloaded_file.download_version
+        output_filepath_string = 'stdout' if output_filepath == STDOUT_FILEPATH else str(
+            output_filepath.resolve()
+        )
         self._print_file_attribute('File name', download_version.file_name)
         self._print_file_attribute('File id', download_version.id_)
+        self._print_file_attribute('Output file path', output_filepath_string)
         self._print_file_attribute('File size', str(download_version.content_length))
         self._print_file_attribute('Content type', download_version.content_type)
         self._print_file_attribute('Content sha1', download_version.content_sha1)
@@ -1686,8 +1692,10 @@ class DownloadFileBase(
             b2_uri, progress_listener, encryption=encryption_setting
         )
 
-        self._print_download_info(downloaded_file)
         output_filepath = self.get_local_output_filepath(args.localFileName, downloaded_file)
+        self._print_download_info(downloaded_file, output_filepath)
+        progress_listener.change_description(output_filepath.name)
+
         downloaded_file.save_to(output_filepath)
         self._print('Download finished')
 

--- a/changelog.d/+downloaded-file-name.added.md
+++ b/changelog.d/+downloaded-file-name.added.md
@@ -1,0 +1,1 @@
+Ensured that the name of the output file is printed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete>=2,<4
 arrow>=1.0.2,<2.0.0
-b2sdk>=1.28.0,<2
+b2sdk>=1.29.0,<2
 docutils>=0.18.1
 idna~=3.4; platform_system == 'Java'
 importlib-metadata~=3.3; python_version < '3.8'

--- a/test/unit/console_tool/test_download_file.py
+++ b/test/unit/console_tool/test_download_file.py
@@ -16,6 +16,7 @@ import pytest
 EXPECTED_STDOUT_DOWNLOAD = '''
 File name:           file1.txt
 File id:             9999
+Output file path:    {output_path}
 File size:           11
 Content type:        b2/x-auto
 Content sha1:        2aae6c35c94fcfb415dbe95f408b9ce91ee846ed
@@ -40,7 +41,8 @@ def test_download_file_by_uri__flag_support(b2_cli, uploaded_file, tmp_path, fla
 
     b2_cli.run(
         ['download-file', flag, 'b2id://9999',
-         str(output_path)], expected_stdout=expected_stdout
+         str(output_path)],
+        expected_stdout=expected_stdout.format(output_path=pathlib.Path(output_path).resolve())
     )
     assert output_path.read_text() == uploaded_file['content']
 
@@ -53,7 +55,10 @@ def test_download_file_by_uri__b2_uri_support(b2_cli, uploaded_file, tmp_path, b
     output_path = tmp_path / 'output.txt'
 
     b2_cli.run(
-        ['download-file', b2_uri, str(output_path)], expected_stdout=EXPECTED_STDOUT_DOWNLOAD
+        ['download-file', b2_uri, str(output_path)],
+        expected_stdout=EXPECTED_STDOUT_DOWNLOAD.format(
+            output_path=pathlib.Path(output_path).resolve()
+        )
     )
     assert output_path.read_text() == uploaded_file['content']
 
@@ -73,7 +78,9 @@ def test_download_file_by_name(b2_cli, local_file, uploaded_file, tmp_path, flag
             'download-file-by-name', uploaded_file['bucket'], uploaded_file['fileName'],
             str(output_path)
         ],
-        expected_stdout=EXPECTED_STDOUT_DOWNLOAD,
+        expected_stdout=EXPECTED_STDOUT_DOWNLOAD.format(
+            output_path=pathlib.Path(output_path).resolve()
+        ),
         expected_stderr=
         'WARNING: download-file-by-name command is deprecated. Use download-file instead.\n',
     )
@@ -92,7 +99,7 @@ def test_download_file_by_id(b2_cli, uploaded_file, tmp_path, flag, expected_std
 
     b2_cli.run(
         ['download-file-by-id', flag, '9999', str(output_path)],
-        expected_stdout=expected_stdout,
+        expected_stdout=expected_stdout.format(output_path=pathlib.Path(output_path).resolve()),
         expected_stderr=
         'WARNING: download-file-by-id command is deprecated. Use download-file instead.\n',
     )
@@ -120,7 +127,9 @@ def test_download_file_by_name__named_pipe(
             uploaded_file['fileName'],
             str(output_path)
         ],
-        expected_stdout=EXPECTED_STDOUT_DOWNLOAD,
+        expected_stdout=EXPECTED_STDOUT_DOWNLOAD.format(
+            output_path=pathlib.Path(output_path).resolve()
+        ),
         expected_stderr=
         'WARNING: download-file-by-name command is deprecated. Use download-file instead.\n',
     )

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -973,9 +973,10 @@ class TestConsoleTool(BaseConsoleToolTest):
 
             # Download by name
             local_download1 = os.path.join(temp_dir, 'download1.txt')
-            expected_stdout = '''
+            expected_stdout_template = '''
             File name:           file1.txt
             File id:             9999
+            Output file path:    {output_path}
             File size:           11
             Content type:        b2/x-auto
             Content sha1:        2aae6c35c94fcfb415dbe95f408b9ce91ee846ed
@@ -986,6 +987,9 @@ class TestConsoleTool(BaseConsoleToolTest):
             Checksum matches
             Download finished
             '''
+            expected_stdout = expected_stdout_template.format(
+                output_path=pathlib.Path(local_download1).resolve()
+            )
 
             self._run_command(
                 ['download-file', '--noProgress', 'b2://my-bucket/file1.txt', local_download1],
@@ -996,6 +1000,9 @@ class TestConsoleTool(BaseConsoleToolTest):
 
             # Download file by ID.  (Same expected output as downloading by name)
             local_download2 = os.path.join(temp_dir, 'download2.txt')
+            expected_stdout = expected_stdout_template.format(
+                output_path=pathlib.Path(local_download2).resolve()
+            )
             self._run_command(
                 ['download-file', '--noProgress', 'b2id://9999', local_download2], expected_stdout,
                 '', 0


### PR DESCRIPTION
Two places are updated:
- "Output file path" is added to the download info printing
- Output file name is presented on the progress bar