### PR TITLE
ApiVer introduced into CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
         id: hashes
         run: nox -vs make_dist_digest
       - name: Run integration tests (without secrets)
-        run: nox -vs integration -- -m "not require_secrets"
+        run: nox -vs integration -- --sut=${{ steps.bundle.outputs.sut_path }} -m "not require_secrets"
       - name: Run integration tests (with secrets)
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
         run: nox -vs integration -- --sut=${{ steps.bundle.outputs.sut_path }} -m "require_secrets" --cleanup
@@ -206,7 +206,7 @@ jobs:
         id: hashes
         run: nox -vs make_dist_digest
       - name: Run integration tests (without secrets)
-        run: nox -vs integration -- -m "not require_secrets"
+        run: nox -vs integration -- --sut=${{ steps.bundle.outputs.sut_path }} -m "not require_secrets"
       - name: Run integration tests (with secrets)
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
         run: nox -vs integration -- --sut=${{ steps.bundle.outputs.sut_path }} -m "require_secrets" --cleanup

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv
 doc/source/main_help.rst
 Dockerfile
 b2/licenses_output.txt
+*.spec

--- a/README.md
+++ b/README.md
@@ -155,6 +155,26 @@ or by mounting local files in the docker container:
 docker run --rm -v b2:/root -v /home/user/path/to/data:/data backblazeit/b2:latest upload-file bucket_name /data/source_file.txt target_file_name
 ```
 
+## Versions
+
+When you start working with `b2`, you might notice that more than one script is available to you.
+This is by design - we use the `ApiVer` methodology to provide all the commands to all the versions
+while also providing all the bugfixes to all the old versions.
+
+If you use the `b2` command, you're working with the latest stable version.
+It provides all the bells and whistles, latest features, and the best performance.
+While it's a great version to work with, if you're willing to write a reliable, long-running script,
+you might find out that after some time it will break.
+New commands will appear, older will deprecate and be removed, parameters will change.
+Backblaze service evolves and the `b2` CLI evolves with it.
+
+However, now you have a way around this problem.
+Instead of using the `b2` command, you can use a version-bound interface e.g.: `b2v3`.
+This command will always provide the same interface that the `ApiVer` version `3` provided.
+Even if the `b2` command goes into the `ApiVer` version `4`, `6` or even `10` with some major changes,
+`b2v3` will still provide the same interface, same commands, and same parameters.
+Over time, it might get slower as we may need to emulate some older behaviors, but we'll ensure that it won't break.
+
 ## Contrib
 
 ### Detailed logs

--- a/b2.spec.template
+++ b/b2.spec.template
@@ -8,7 +8,7 @@ block_cipher = None
 # https://github.com/Backblaze/B2_Command_Line_Tool/issues/689
 datas = copy_metadata('b2') + collect_data_files('dateutil')
 
-a = Analysis(['b2/console_tool.py'],
+a = Analysis(['b2/_internal/${VERSION}/__main__.py'],
              pathex=['.'],
              binaries=[],
              datas=datas,
@@ -30,7 +30,7 @@ exe = EXE(pyz,
           a.zipfiles,
           a.datas,
           [],
-          name='b2',
+          name='${NAME}',
           debug=False,
           bootloader_ignore_signals=False,
           strip=False,

--- a/b2/__init__.py
+++ b/b2/__init__.py
@@ -13,7 +13,7 @@ import logging  # noqa
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-import b2.version  # noqa: E402
+import b2._internal.version  # noqa: E402
 
-__version__ = b2.version.VERSION
+__version__ = b2._internal.version.VERSION
 assert __version__  # PEP-0396

--- a/b2/_internal/__init__.py
+++ b/b2/_internal/__init__.py
@@ -1,0 +1,9 @@
+######################################################################
+#
+# File: b2/_internal/__init__.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################

--- a/b2/_internal/_b2v4/__init__.py
+++ b/b2/_internal/_b2v4/__init__.py
@@ -1,0 +1,11 @@
+######################################################################
+#
+# File: b2/_internal/_b2v4/__init__.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+# Note: importing console_tool in any shape or form in here will break sys.argv.

--- a/b2/_internal/_b2v4/__main__.py
+++ b/b2/_internal/_b2v4/__main__.py
@@ -1,0 +1,13 @@
+######################################################################
+#
+# File: b2/_internal/_b2v4/__main__.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+from b2._internal._b2v4.registry import main
+
+main()

--- a/b2/_internal/_b2v4/registry.py
+++ b/b2/_internal/_b2v4/registry.py
@@ -1,0 +1,57 @@
+######################################################################
+#
+# File: b2/_internal/_b2v4/registry.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+# ruff: noqa: F405
+from b2._internal.console_tool import *  # noqa
+
+B2.register_subcommand(AuthorizeAccount)
+B2.register_subcommand(CancelAllUnfinishedLargeFiles)
+B2.register_subcommand(CancelLargeFile)
+B2.register_subcommand(ClearAccount)
+B2.register_subcommand(CopyFileById)
+B2.register_subcommand(CreateBucket)
+B2.register_subcommand(CreateKey)
+B2.register_subcommand(DeleteBucket)
+B2.register_subcommand(DeleteFileVersion)
+B2.register_subcommand(DeleteKey)
+B2.register_subcommand(DownloadFile)
+B2.register_subcommand(DownloadFileById)
+B2.register_subcommand(DownloadFileByName)
+B2.register_subcommand(Cat)
+B2.register_subcommand(GetAccountInfo)
+B2.register_subcommand(GetBucket)
+B2.register_subcommand(FileInfo)
+B2.register_subcommand(GetFileInfo)
+B2.register_subcommand(GetDownloadAuth)
+B2.register_subcommand(GetDownloadUrlWithAuth)
+B2.register_subcommand(HideFile)
+B2.register_subcommand(ListBuckets)
+B2.register_subcommand(ListKeys)
+B2.register_subcommand(ListParts)
+B2.register_subcommand(ListUnfinishedLargeFiles)
+B2.register_subcommand(Ls)
+B2.register_subcommand(Rm)
+B2.register_subcommand(GetUrl)
+B2.register_subcommand(MakeUrl)
+B2.register_subcommand(MakeFriendlyUrl)
+B2.register_subcommand(Sync)
+B2.register_subcommand(UpdateBucket)
+B2.register_subcommand(UploadFile)
+B2.register_subcommand(UploadUnboundStream)
+B2.register_subcommand(UpdateFileLegalHold)
+B2.register_subcommand(UpdateFileRetention)
+B2.register_subcommand(ReplicationSetup)
+B2.register_subcommand(ReplicationDelete)
+B2.register_subcommand(ReplicationPause)
+B2.register_subcommand(ReplicationUnpause)
+B2.register_subcommand(ReplicationStatus)
+B2.register_subcommand(Version)
+B2.register_subcommand(License)
+B2.register_subcommand(InstallAutocomplete)

--- a/b2/_internal/_cli/__init__.py
+++ b/b2/_internal/_cli/__init__.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_cli/__init__.py
+# File: b2/_internal/_cli/__init__.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #

--- a/b2/_internal/_cli/arg_parser_types.py
+++ b/b2/_internal/_cli/arg_parser_types.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_cli/arg_parser_types.py
+# File: b2/_internal/_cli/arg_parser_types.py
 #
 # Copyright 2020 Backblaze Inc. All Rights Reserved.
 #

--- a/b2/_internal/_cli/argcompleters.py
+++ b/b2/_internal/_cli/argcompleters.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_cli/argcompleters.py
+# File: b2/_internal/_cli/argcompleters.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #
@@ -16,7 +16,7 @@ from itertools import islice
 
 
 def bucket_name_completer(prefix, parsed_args, **kwargs):
-    from b2._cli.b2api import _get_b2api_for_profile
+    from b2._internal._cli.b2api import _get_b2api_for_profile
     api = _get_b2api_for_profile(getattr(parsed_args, 'profile', None))
     res = [bucket.name for bucket in api.list_buckets(use_cache=True)]
     return res
@@ -30,7 +30,7 @@ def file_name_completer(prefix, parsed_args, **kwargs):
     """
     from b2sdk.v2 import LIST_FILE_NAMES_MAX_LIMIT
 
-    from b2._cli.b2api import _get_b2api_for_profile
+    from b2._internal._cli.b2api import _get_b2api_for_profile
 
     api = _get_b2api_for_profile(parsed_args.profile)
     bucket = api.get_bucket_by_name(parsed_args.bucketName)
@@ -52,9 +52,9 @@ def b2uri_file_completer(prefix: str, parsed_args, **kwargs):
     """
     from b2sdk.v2 import LIST_FILE_NAMES_MAX_LIMIT
 
-    from b2._cli.b2api import _get_b2api_for_profile
-    from b2._utils.python_compat import removeprefix
-    from b2._utils.uri import parse_b2_uri
+    from b2._internal._cli.b2api import _get_b2api_for_profile
+    from b2._internal._utils.python_compat import removeprefix
+    from b2._internal._utils.uri import parse_b2_uri
 
     api = _get_b2api_for_profile(getattr(parsed_args, 'profile', None))
     if prefix.startswith('b2://'):

--- a/b2/_internal/_cli/autocomplete_cache.py
+++ b/b2/_internal/_cli/autocomplete_cache.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_cli/autocomplete_cache.py
+# File: b2/_internal/_cli/autocomplete_cache.py
 #
 # Copyright 2020 Backblaze Inc. All Rights Reserved.
 #
@@ -19,7 +19,7 @@ from typing import Callable
 import argcomplete
 import platformdirs
 
-from b2.version import VERSION
+from b2._internal.version import VERSION
 
 
 def identity(x):

--- a/b2/_internal/_cli/autocomplete_install.py
+++ b/b2/_internal/_cli/autocomplete_install.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_cli/autocomplete_install.py
+# File: b2/_internal/_cli/autocomplete_install.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #

--- a/b2/_internal/_cli/b2api.py
+++ b/b2/_internal/_cli/b2api.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_cli/b2api.py
+# File: b2/_internal/_cli/b2api.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #
@@ -18,7 +18,7 @@ from b2sdk.v2 import (
     SqliteAccountInfo,
 )
 
-from b2._cli.const import B2_USER_AGENT_APPEND_ENV_VAR
+from b2._internal._cli.const import B2_USER_AGENT_APPEND_ENV_VAR
 
 
 def _get_b2api_for_profile(profile: Optional[str] = None, **kwargs) -> B2Api:

--- a/b2/_internal/_cli/b2args.py
+++ b/b2/_internal/_cli/b2args.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_cli/b2args.py
+# File: b2/_internal/_cli/b2args.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #
@@ -12,9 +12,9 @@ Utility functions for adding b2-specific arguments to an argparse parser.
 """
 import argparse
 
-from b2._cli.arg_parser_types import wrap_with_argument_type_error
-from b2._cli.argcompleters import b2uri_file_completer
-from b2._utils.uri import B2URI, B2URIBase, parse_b2_uri
+from b2._internal._cli.arg_parser_types import wrap_with_argument_type_error
+from b2._internal._cli.argcompleters import b2uri_file_completer
+from b2._internal._utils.uri import B2URI, B2URIBase, parse_b2_uri
 
 
 def b2_file_uri(value: str) -> B2URIBase:

--- a/b2/_internal/_cli/const.py
+++ b/b2/_internal/_cli/const.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_cli/const.py
+# File: b2/_internal/_cli/const.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #

--- a/b2/_internal/_cli/obj_loads.py
+++ b/b2/_internal/_cli/obj_loads.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_cli/obj_loads.py
+# File: b2/_internal/_cli/obj_loads.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #

--- a/b2/_internal/_cli/shell.py
+++ b/b2/_internal/_cli/shell.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_cli/shell.py
+# File: b2/_internal/_cli/shell.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #

--- a/b2/_internal/_utils/__init__.py
+++ b/b2/_internal/_utils/__init__.py
@@ -1,13 +1,9 @@
 ######################################################################
 #
-# File: b2/__main__.py
+# File: b2/_internal/_utils/__init__.py
 #
-# Copyright 2019 Backblaze Inc. All Rights Reserved.
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
 #
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
-
-from .console_tool import main
-
-main()

--- a/b2/_internal/_utils/python_compat.py
+++ b/b2/_internal/_utils/python_compat.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_utils/python_compat.py
+# File: b2/_internal/_utils/python_compat.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #

--- a/b2/_internal/_utils/uri.py
+++ b/b2/_internal/_utils/uri.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/_utils/uri.py
+# File: b2/_internal/_utils/uri.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #
@@ -20,7 +20,7 @@ from b2sdk.v2 import (
     FileVersion,
 )
 
-from b2._utils.python_compat import removeprefix, singledispatchmethod
+from b2._internal._utils.python_compat import removeprefix, singledispatchmethod
 
 
 class B2URIBase:

--- a/b2/_internal/arg_parser.py
+++ b/b2/_internal/arg_parser.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/arg_parser.py
+# File: b2/_internal/arg_parser.py
 #
 # Copyright 2020 Backblaze Inc. All Rights Reserved.
 #

--- a/b2/_internal/b2v3/__init__.py
+++ b/b2/_internal/b2v3/__init__.py
@@ -1,9 +1,11 @@
 ######################################################################
 #
-# File: b2/_utils/__init__.py
+# File: b2/_internal/b2v3/__init__.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+
+# Note: importing console_tool in any shape or form in here will break sys.argv.

--- a/b2/_internal/b2v3/__main__.py
+++ b/b2/_internal/b2v3/__main__.py
@@ -1,0 +1,13 @@
+######################################################################
+#
+# File: b2/_internal/b2v3/__main__.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+from b2._internal.b2v3.registry import main
+
+main()

--- a/b2/_internal/b2v3/registry.py
+++ b/b2/_internal/b2v3/registry.py
@@ -1,0 +1,57 @@
+######################################################################
+#
+# File: b2/_internal/b2v3/registry.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+# ruff: noqa: F405
+from b2._internal._b2v4.registry import *  # noqa
+
+B2.register_subcommand(AuthorizeAccount)
+B2.register_subcommand(CancelAllUnfinishedLargeFiles)
+B2.register_subcommand(CancelLargeFile)
+B2.register_subcommand(ClearAccount)
+B2.register_subcommand(CopyFileById)
+B2.register_subcommand(CreateBucket)
+B2.register_subcommand(CreateKey)
+B2.register_subcommand(DeleteBucket)
+B2.register_subcommand(DeleteFileVersion)
+B2.register_subcommand(DeleteKey)
+B2.register_subcommand(DownloadFile)
+B2.register_subcommand(DownloadFileById)
+B2.register_subcommand(DownloadFileByName)
+B2.register_subcommand(Cat)
+B2.register_subcommand(GetAccountInfo)
+B2.register_subcommand(GetBucket)
+B2.register_subcommand(FileInfo)
+B2.register_subcommand(GetFileInfo)
+B2.register_subcommand(GetDownloadAuth)
+B2.register_subcommand(GetDownloadUrlWithAuth)
+B2.register_subcommand(HideFile)
+B2.register_subcommand(ListBuckets)
+B2.register_subcommand(ListKeys)
+B2.register_subcommand(ListParts)
+B2.register_subcommand(ListUnfinishedLargeFiles)
+B2.register_subcommand(Ls)
+B2.register_subcommand(Rm)
+B2.register_subcommand(GetUrl)
+B2.register_subcommand(MakeUrl)
+B2.register_subcommand(MakeFriendlyUrl)
+B2.register_subcommand(Sync)
+B2.register_subcommand(UpdateBucket)
+B2.register_subcommand(UploadFile)
+B2.register_subcommand(UploadUnboundStream)
+B2.register_subcommand(UpdateFileLegalHold)
+B2.register_subcommand(UpdateFileRetention)
+B2.register_subcommand(ReplicationSetup)
+B2.register_subcommand(ReplicationDelete)
+B2.register_subcommand(ReplicationPause)
+B2.register_subcommand(ReplicationUnpause)
+B2.register_subcommand(ReplicationStatus)
+B2.register_subcommand(Version)
+B2.register_subcommand(License)
+B2.register_subcommand(InstallAutocomplete)

--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -2,18 +2,19 @@
 # PYTHON_ARGCOMPLETE_OK
 ######################################################################
 #
-# File: b2/console_tool.py
+# File: b2/_internal/console_tool.py
 #
 # Copyright 2019 Backblaze Inc. All Rights Reserved.
 #
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+# ruff: noqa: E402
 from __future__ import annotations
 
 import tempfile
 
-from b2._cli.autocomplete_cache import AUTOCOMPLETE  # noqa
+from b2._internal._cli.autocomplete_cache import AUTOCOMPLETE  # noqa
 
 AUTOCOMPLETE.autocomplete_from_cache()
 
@@ -111,21 +112,21 @@ from b2sdk.version import VERSION as b2sdk_version
 from class_registry import ClassRegistry
 from tabulate import tabulate
 
-from b2._cli.arg_parser_types import (
+from b2._internal._cli.arg_parser_types import (
     parse_comma_separated_list,
     parse_default_retention_period,
     parse_millis_from_float_timestamp,
     parse_range,
 )
-from b2._cli.argcompleters import bucket_name_completer, file_name_completer
-from b2._cli.autocomplete_install import (
+from b2._internal._cli.argcompleters import bucket_name_completer, file_name_completer
+from b2._internal._cli.autocomplete_install import (
     SUPPORTED_SHELLS,
     AutocompleteInstallError,
     autocomplete_install,
 )
-from b2._cli.b2api import _get_b2api_for_profile
-from b2._cli.b2args import add_b2_file_argument
-from b2._cli.const import (
+from b2._internal._cli.b2api import _get_b2api_for_profile
+from b2._internal._cli.b2args import add_b2_file_argument
+from b2._internal._cli.const import (
     B2_APPLICATION_KEY_ENV_VAR,
     B2_APPLICATION_KEY_ID_ENV_VAR,
     B2_DESTINATION_SSE_C_KEY_B64_ENV_VAR,
@@ -136,12 +137,12 @@ from b2._cli.const import (
     CREATE_BUCKET_TYPES,
     DEFAULT_THREADS,
 )
-from b2._cli.obj_loads import validated_loads
-from b2._cli.shell import detect_shell
-from b2._utils.uri import B2URI, B2FileIdURI, B2URIAdapter, B2URIBase
-from b2.arg_parser import B2ArgumentParser
-from b2.json_encoder import B2CliJsonEncoder
-from b2.version import VERSION
+from b2._internal._cli.obj_loads import validated_loads
+from b2._internal._cli.shell import detect_shell
+from b2._internal._utils.uri import B2URI, B2FileIdURI, B2URIAdapter, B2URIBase
+from b2._internal.arg_parser import B2ArgumentParser
+from b2._internal.json_encoder import B2CliJsonEncoder
+from b2._internal.version import VERSION
 
 piplicenses = None
 prettytable = None
@@ -160,7 +161,10 @@ VERSION_0_COMPATIBILITY = False
 # The name of an executable entry point
 NAME = os.path.basename(sys.argv[0])
 if NAME.endswith('.py'):
-    NAME = 'b2'
+    version_name = re.search(
+        r'[\\/]b2[\\/]_internal[\\/](_{0,1}b2v\d+)[\\/]__main__.py', sys.argv[0]
+    )
+    NAME = version_name.group(1) if version_name else 'b2'
 
 FILE_RETENTION_COMPATIBILITY_WARNING = """
     .. warning::
@@ -997,7 +1001,6 @@ class B2(Command):
         return args.command_class
 
 
-@B2.register_subcommand
 class AuthorizeAccount(Command):
     """
     Prompts for Backblaze ``applicationKeyId`` and ``applicationKey`` (unless they are given
@@ -1122,7 +1125,6 @@ class AuthorizeAccount(Command):
         return os.environ.get(B2_ENVIRONMENT_ENV_VAR)
 
 
-@B2.register_subcommand
 class CancelAllUnfinishedLargeFiles(Command):
     """
     Lists all large files that have been started but not
@@ -1148,7 +1150,6 @@ class CancelAllUnfinishedLargeFiles(Command):
         return 0
 
 
-@B2.register_subcommand
 class CancelLargeFile(Command):
     """
     Cancels a large file upload.  Used to undo a ``start-large-file``.
@@ -1172,7 +1173,6 @@ class CancelLargeFile(Command):
         return 0
 
 
-@B2.register_subcommand
 class ClearAccount(Command):
     """
     Erases everything in local cache.
@@ -1193,7 +1193,6 @@ class ClearAccount(Command):
         return 0
 
 
-@B2.register_subcommand
 class CopyFileById(
     HeaderFlagsMixin, DestinationSseMixin, SourceSseMixin, FileRetentionSettingMixin,
     LegalHoldMixin, Command
@@ -1331,7 +1330,6 @@ class CopyFileById(
         return source_file_version.file_info, source_file_version.content_type
 
 
-@B2.register_subcommand
 class CreateBucket(DefaultSseMixin, LifecycleRulesMixin, Command):
     """
     Creates a new bucket.  Prints the ID of the bucket created.
@@ -1387,7 +1385,6 @@ class CreateBucket(DefaultSseMixin, LifecycleRulesMixin, Command):
         return 0
 
 
-@B2.register_subcommand
 class CreateKey(Command):
     """
     Creates a new application key.  Prints the application key information.  This is the only
@@ -1448,7 +1445,6 @@ class CreateKey(Command):
         return 0
 
 
-@B2.register_subcommand
 class DeleteBucket(Command):
     """
     Deletes the bucket with the given name.
@@ -1469,7 +1465,6 @@ class DeleteBucket(Command):
         return 0
 
 
-@B2.register_subcommand
 class DeleteFileVersion(FileIdAndOptionalFileNameMixin, Command):
     """
     Permanently and irrevocably deletes one version of a file.
@@ -1501,7 +1496,6 @@ class DeleteFileVersion(FileIdAndOptionalFileNameMixin, Command):
         return 0
 
 
-@B2.register_subcommand
 class DeleteKey(Command):
     """
     Deletes the specified application key by its ID.
@@ -1694,7 +1688,6 @@ class DownloadFileBase(
         return 0
 
 
-@B2.register_subcommand
 class DownloadFile(B2URIFileArgMixin, DownloadFileBase):
     __doc__ = DownloadFileBase.__doc__
 
@@ -1707,7 +1700,6 @@ class DownloadFile(B2URIFileArgMixin, DownloadFileBase):
         return args.B2_URI
 
 
-@B2.register_subcommand
 class DownloadFileById(CmdReplacedByMixin, B2URIFileIDArgMixin, DownloadFileBase):
     __doc__ = DownloadFileBase.__doc__
     replaced_by_cmd = DownloadFile
@@ -1718,7 +1710,6 @@ class DownloadFileById(CmdReplacedByMixin, B2URIFileIDArgMixin, DownloadFileBase
         parser.add_argument('localFileName')
 
 
-@B2.register_subcommand
 class DownloadFileByName(CmdReplacedByMixin, B2URIBucketNFilenameArgMixin, DownloadFileBase):
     __doc__ = DownloadFileBase.__doc__
     replaced_by_cmd = DownloadFile
@@ -1729,7 +1720,6 @@ class DownloadFileByName(CmdReplacedByMixin, B2URIBucketNFilenameArgMixin, Downl
         parser.add_argument('localFileName')
 
 
-@B2.register_subcommand
 class Cat(B2URIFileArgMixin, DownloadCommand):
     """
     Download content of a file-like object identified by B2 URI directly to stdout.
@@ -1758,7 +1748,6 @@ class Cat(B2URIFileArgMixin, DownloadCommand):
         return 0
 
 
-@B2.register_subcommand
 class GetAccountInfo(Command):
     """
     Shows the account ID, key, auth token, URLs, and what capabilities
@@ -1787,7 +1776,6 @@ class GetAccountInfo(Command):
         return 0
 
 
-@B2.register_subcommand
 class GetBucket(Command):
     """
     Prints all of the information about the bucket, including
@@ -1864,18 +1852,15 @@ class FileInfoBase(Command):
         return 0
 
 
-@B2.register_subcommand
 class FileInfo(B2URIFileArgMixin, FileInfoBase):
     __doc__ = FileInfoBase.__doc__
 
 
-@B2.register_subcommand
 class GetFileInfo(CmdReplacedByMixin, B2URIFileIDArgMixin, FileInfoBase):
     __doc__ = FileInfoBase.__doc__
     replaced_by_cmd = FileInfo
 
 
-@B2.register_subcommand
 class GetDownloadAuth(Command):
     """
     Prints an authorization token that is valid only for downloading
@@ -1909,7 +1894,6 @@ class GetDownloadAuth(Command):
         return 0
 
 
-@B2.register_subcommand
 class GetDownloadUrlWithAuth(Command):
     """
     Prints a URL to download the given file.  The URL includes an authorization
@@ -1946,7 +1930,6 @@ class GetDownloadUrlWithAuth(Command):
         return 0
 
 
-@B2.register_subcommand
 class HideFile(Command):
     """
     Uploads a new, hidden, version of the given file.
@@ -1969,7 +1952,6 @@ class HideFile(Command):
         return 0
 
 
-@B2.register_subcommand
 class ListBuckets(Command):
     """
     Lists all of the buckets in the current account.
@@ -2005,7 +1987,6 @@ class ListBuckets(Command):
         return 0
 
 
-@B2.register_subcommand
 class ListKeys(Command):
     """
     Lists the application keys for the current account.
@@ -2087,7 +2068,6 @@ class ListKeys(Command):
             return dt.strftime('%Y-%m-%d'), dt.strftime('%H:%M:%S')
 
 
-@B2.register_subcommand
 class ListParts(Command):
     """
     Lists all of the parts that have been uploaded for the given
@@ -2110,7 +2090,6 @@ class ListParts(Command):
         return 0
 
 
-@B2.register_subcommand
 class ListUnfinishedLargeFiles(Command):
     """
     Lists all of the large files in the bucket that were started,
@@ -2193,7 +2172,6 @@ class AbstractLsCommand(Command, metaclass=ABCMeta):
             raise B2Error(error.args[0])
 
 
-@B2.register_subcommand
 class Ls(AbstractLsCommand):
     """
     Using the file naming convention that ``/`` separates folder
@@ -2313,7 +2291,6 @@ class Ls(AbstractLsCommand):
         return template % tuple(parameters)
 
 
-@B2.register_subcommand
 class Rm(ThreadsMixin, AbstractLsCommand):
     """
     Removes a "folder" or a set of files matching a pattern.  Use with caution.
@@ -2533,24 +2510,20 @@ class GetUrlBase(Command):
         return 0
 
 
-@B2.register_subcommand
 class GetUrl(B2URIFileArgMixin, GetUrlBase):
     __doc__ = GetUrlBase.__doc__
 
 
-@B2.register_subcommand
 class MakeUrl(CmdReplacedByMixin, B2URIFileIDArgMixin, GetUrlBase):
     __doc__ = GetUrlBase.__doc__
     replaced_by_cmd = GetUrl
 
 
-@B2.register_subcommand
 class MakeFriendlyUrl(CmdReplacedByMixin, B2URIBucketNFilenameArgMixin, GetUrlBase):
     __doc__ = GetUrlBase.__doc__
     replaced_by_cmd = GetUrl
 
 
-@B2.register_subcommand
 class Sync(
     ThreadsMixin,
     DestinationSseMixin,
@@ -2896,7 +2869,6 @@ class Sync(
         )
 
 
-@B2.register_subcommand
 class UpdateBucket(DefaultSseMixin, LifecycleRulesMixin, Command):
     """
     Updates the ``bucketType`` of an existing bucket.  Prints the ID
@@ -3170,7 +3142,6 @@ class UploadFileMixin(
         pass
 
 
-@B2.register_subcommand
 class UploadFile(UploadFileMixin, UploadModeMixin, Command):
     """
     Uploads one file to the given bucket.
@@ -3230,7 +3201,6 @@ class UploadFile(UploadFileMixin, UploadModeMixin, Command):
         return file_version
 
 
-@B2.register_subcommand
 class UploadUnboundStream(UploadFileMixin, Command):
     """
     Uploads an unbound stream to the given bucket.
@@ -3311,7 +3281,6 @@ class UploadUnboundStream(UploadFileMixin, Command):
         return file_version
 
 
-@B2.register_subcommand
 class UpdateFileLegalHold(FileIdAndOptionalFileNameMixin, Command):
     """
     Only works in buckets with fileLockEnabled=true.
@@ -3337,7 +3306,6 @@ class UpdateFileLegalHold(FileIdAndOptionalFileNameMixin, Command):
         return 0
 
 
-@B2.register_subcommand
 class UpdateFileRetention(FileIdAndOptionalFileNameMixin, Command):
     """
     Only works in buckets with fileLockEnabled=true. Providing a ``retentionMode`` other than ``none`` requires
@@ -3396,7 +3364,6 @@ class UpdateFileRetention(FileIdAndOptionalFileNameMixin, Command):
         return 0
 
 
-@B2.register_subcommand
 class ReplicationSetup(Command):
     """
     Sets up replication between two buckets (potentially from different accounts), creating and replacing keys if necessary.
@@ -3518,7 +3485,6 @@ class ReplicationRuleChanger(Command, metaclass=ABCMeta):
         pass
 
 
-@B2.register_subcommand
 class ReplicationDelete(ReplicationRuleChanger):
     """
     Deletes a replication rule
@@ -3535,7 +3501,6 @@ class ReplicationDelete(ReplicationRuleChanger):
         return None
 
 
-@B2.register_subcommand
 class ReplicationPause(ReplicationRuleChanger):
     """
     Pauses a replication rule
@@ -3553,7 +3518,6 @@ class ReplicationPause(ReplicationRuleChanger):
         return rule
 
 
-@B2.register_subcommand
 class ReplicationUnpause(ReplicationRuleChanger):
     """
     Unpauses a replication rule
@@ -3571,7 +3535,6 @@ class ReplicationUnpause(ReplicationRuleChanger):
         return rule
 
 
-@B2.register_subcommand
 class ReplicationStatus(Command):
     """
     Inspects files in only source or both source and destination buckets
@@ -3738,7 +3701,6 @@ class ReplicationStatus(Command):
         writer.writerows(rows)
 
 
-@B2.register_subcommand
 class Version(Command):
     """
     Prints the version number of this tool.
@@ -3759,12 +3721,11 @@ class Version(Command):
         return 0
 
 
-@B2.register_subcommand
 class License(Command):  # pragma: no cover
     """
     Prints the license of B2 Command line tool and all libraries shipped with it.
     """
-    LICENSE_OUTPUT_FILE = pathlib.Path(__file__).parent / 'licenses_output.txt'
+    LICENSE_OUTPUT_FILE = pathlib.Path(__file__).parent.parent / 'licenses_output.txt'
 
     REQUIRES_AUTH = False
     IGNORE_MODULES = {'b2', 'distlib', 'patchelf-wrapper', 'platformdirs'}
@@ -3851,7 +3812,7 @@ class License(Command):  # pragma: no cover
                 files_table.add_row([file_name, file_content])
             stream.write(str(files_table))
         stream.write(f'\n\n{NAME} license:\n')
-        b2_license_file_text = (pathlib.Path(__file__).parent /
+        b2_license_file_text = (pathlib.Path(__file__).parent.parent /
                                 'LICENSE').read_text(encoding='utf8')
         stream.write(b2_license_file_text)
 
@@ -3944,7 +3905,6 @@ class License(Command):  # pragma: no cover
         return license_
 
 
-@B2.register_subcommand
 class InstallAutocomplete(Command):
     """
     Installs autocomplete for supported shells.

--- a/b2/_internal/json_encoder.py
+++ b/b2/_internal/json_encoder.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/json_encoder.py
+# File: b2/_internal/json_encoder.py
 #
 # Copyright 2020 Backblaze Inc. All Rights Reserved.
 #

--- a/b2/_internal/version.py
+++ b/b2/_internal/version.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2/version.py
+# File: b2/_internal/version.py
 #
 # Copyright 2019 Backblaze Inc. All Rights Reserved.
 #

--- a/b2/_internal/version_listing.py
+++ b/b2/_internal/version_listing.py
@@ -1,0 +1,32 @@
+######################################################################
+#
+# File: b2/_internal/version_listing.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+import pathlib
+import re
+from typing import List
+
+RE_VERSION = re.compile(r'[_]*b2v(\d+)')
+
+
+def get_versions() -> List[str]:
+    return [path.name for path in sorted(pathlib.Path(__file__).parent.glob('*b2v*'))]
+
+
+def get_int_version(version: str) -> int:
+    match = RE_VERSION.match(version)
+    assert match, f'Version {version} does not match pattern {RE_VERSION.pattern}'
+    return int(match.group(1))
+
+
+CLI_VERSIONS = get_versions()
+UNSTABLE_CLI_VERSION = max(CLI_VERSIONS, key=get_int_version)
+LATEST_STABLE_VERSION = max(
+    [elem for elem in CLI_VERSIONS if not elem.startswith('_')], key=get_int_version
+)

--- a/changelog.d/+apiver_for_cli.added.md
+++ b/changelog.d/+apiver_for_cli.added.md
@@ -1,0 +1,1 @@
+Client binary is now handled with ApiVer methodology in mind. `b2` executable points to the latest stable version, while other versions can be called directly.

--- a/changelog.d/+apiver_for_cli.added.md
+++ b/changelog.d/+apiver_for_cli.added.md
@@ -1,1 +1,1 @@
-Client binary is now handled with ApiVer methodology in mind. `b2` executable points to the latest stable version, while other versions can be called directly.
+ApiVer introduced. `b2` executable points to the latest stable ApiVer version, while `b2v3` will always point to `v3`.

--- a/changelog.d/+downloaded-file-name.added.md
+++ b/changelog.d/+downloaded-file-name.added.md
@@ -1,1 +1,1 @@
-Ensured that the name of the output file is printed.
+Print output file path in `download-file` command.

--- a/changelog.d/+internal_directory.changed.md
+++ b/changelog.d/+internal_directory.changed.md
@@ -1,1 +1,1 @@
-All the Python libraries were moved to the `_internal` directory to discourage users from importing them.
+All Python modules were moved to the `b2._internal` package to discourage users from importing them.

--- a/changelog.d/+internal_directory.changed.md
+++ b/changelog.d/+internal_directory.changed.md
@@ -1,0 +1,1 @@
+All the Python libraries were moved to the `_internal` directory to discourage users from importing them.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -28,16 +28,20 @@
 #
 
 import datetime
+import importlib
 import os
-from os import path
 import re
 import sys
 import textwrap
+from os import path
 
 sys.path.insert(0, os.path.abspath('../..'))
 
-from b2.console_tool import B2
-from b2.version import VERSION
+from b2._internal.version import VERSION
+from b2._internal.version_listing import LATEST_STABLE_VERSION
+
+B2 = importlib.import_module(f'b2._internal.{LATEST_STABLE_VERSION}.registry').B2
+
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/source/subcommands/authorize_account.rst
+++ b/doc/source/subcommands/authorize_account.rst
@@ -2,7 +2,7 @@ Authorize-account command
 *************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: authorize-account

--- a/doc/source/subcommands/cancel_all_unfinished_large_files.rst
+++ b/doc/source/subcommands/cancel_all_unfinished_large_files.rst
@@ -2,7 +2,7 @@ Cancel-all-unfinished-large-files command
 *****************************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: cancel-all-unfinished-large-files

--- a/doc/source/subcommands/cancel_large_file.rst
+++ b/doc/source/subcommands/cancel_large_file.rst
@@ -2,7 +2,7 @@ Cancel-large-file command
 *************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: cancel-large-file

--- a/doc/source/subcommands/cat.rst
+++ b/doc/source/subcommands/cat.rst
@@ -2,7 +2,7 @@ Cat command
 ****************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: cat

--- a/doc/source/subcommands/clear_account.rst
+++ b/doc/source/subcommands/clear_account.rst
@@ -2,7 +2,7 @@ Clear-account command
 *********************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: clear-account

--- a/doc/source/subcommands/copy_file_by_id.rst
+++ b/doc/source/subcommands/copy_file_by_id.rst
@@ -2,7 +2,7 @@ Copy-file-by-id command
 ***********************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: copy-file-by-id

--- a/doc/source/subcommands/create_bucket.rst
+++ b/doc/source/subcommands/create_bucket.rst
@@ -2,7 +2,7 @@ Create-bucket command
 *********************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: create-bucket

--- a/doc/source/subcommands/create_key.rst
+++ b/doc/source/subcommands/create_key.rst
@@ -2,7 +2,7 @@ Create-key command
 ******************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: create-key

--- a/doc/source/subcommands/delete_bucket.rst
+++ b/doc/source/subcommands/delete_bucket.rst
@@ -2,7 +2,7 @@ Delete-bucket command
 *********************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: delete-bucket

--- a/doc/source/subcommands/delete_file_version.rst
+++ b/doc/source/subcommands/delete_file_version.rst
@@ -2,7 +2,7 @@ Delete-file-version command
 ***************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: delete-file-version

--- a/doc/source/subcommands/delete_key.rst
+++ b/doc/source/subcommands/delete_key.rst
@@ -2,7 +2,7 @@ Delete-key command
 ******************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: delete-key

--- a/doc/source/subcommands/download_file.rst
+++ b/doc/source/subcommands/download_file.rst
@@ -2,7 +2,7 @@ Download-file command
 ***************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: download-file

--- a/doc/source/subcommands/download_file_by_id.rst
+++ b/doc/source/subcommands/download_file_by_id.rst
@@ -2,7 +2,7 @@ Download-file-by-id command
 ***************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: download-file-by-id

--- a/doc/source/subcommands/download_file_by_name.rst
+++ b/doc/source/subcommands/download_file_by_name.rst
@@ -2,7 +2,7 @@ Download-file-by-name command
 *****************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: download-file-by-name

--- a/doc/source/subcommands/file_info.rst
+++ b/doc/source/subcommands/file_info.rst
@@ -2,7 +2,7 @@ File-info command
 *********************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: file-info

--- a/doc/source/subcommands/get_account_info.rst
+++ b/doc/source/subcommands/get_account_info.rst
@@ -2,7 +2,7 @@ Get-account-info command
 ************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: get-account-info

--- a/doc/source/subcommands/get_bucket.rst
+++ b/doc/source/subcommands/get_bucket.rst
@@ -2,7 +2,7 @@ Get-bucket command
 ******************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: get-bucket

--- a/doc/source/subcommands/get_download_auth.rst
+++ b/doc/source/subcommands/get_download_auth.rst
@@ -2,7 +2,7 @@ Get-download-auth command
 *************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: get-download-auth

--- a/doc/source/subcommands/get_download_url_with_auth.rst
+++ b/doc/source/subcommands/get_download_url_with_auth.rst
@@ -2,7 +2,7 @@ Get-download-url-with-auth command
 **********************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: get-download-url-with-auth

--- a/doc/source/subcommands/get_file_info.rst
+++ b/doc/source/subcommands/get_file_info.rst
@@ -2,7 +2,7 @@ Get-file-info command
 *********************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: get-file-info

--- a/doc/source/subcommands/get_url.rst
+++ b/doc/source/subcommands/get_url.rst
@@ -2,7 +2,7 @@ Get-url command
 ****************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: get-url

--- a/doc/source/subcommands/hide_file.rst
+++ b/doc/source/subcommands/hide_file.rst
@@ -2,7 +2,7 @@ Hide-file command
 *****************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: hide-file

--- a/doc/source/subcommands/install_autocomplete.rst
+++ b/doc/source/subcommands/install_autocomplete.rst
@@ -2,7 +2,7 @@ install-autocomplete command
 ****************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: install-autocomplete

--- a/doc/source/subcommands/list_buckets.rst
+++ b/doc/source/subcommands/list_buckets.rst
@@ -2,7 +2,7 @@ List-buckets command
 ********************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: list-buckets

--- a/doc/source/subcommands/list_keys.rst
+++ b/doc/source/subcommands/list_keys.rst
@@ -2,7 +2,7 @@ List-keys command
 *****************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: list-keys

--- a/doc/source/subcommands/list_parts.rst
+++ b/doc/source/subcommands/list_parts.rst
@@ -2,7 +2,7 @@ List-parts command
 ******************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: list-parts

--- a/doc/source/subcommands/list_unfinished_large_files.rst
+++ b/doc/source/subcommands/list_unfinished_large_files.rst
@@ -2,7 +2,7 @@ List-unfinished-large-files command
 ***********************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: list-unfinished-large-files

--- a/doc/source/subcommands/ls.rst
+++ b/doc/source/subcommands/ls.rst
@@ -2,7 +2,7 @@ Ls command
 **********
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: ls

--- a/doc/source/subcommands/make_friendly_url.rst
+++ b/doc/source/subcommands/make_friendly_url.rst
@@ -2,7 +2,7 @@ Make-friendly-url command
 *************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: make-friendly-url

--- a/doc/source/subcommands/make_url.rst
+++ b/doc/source/subcommands/make_url.rst
@@ -2,7 +2,7 @@ Make-url command
 ****************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: make-url

--- a/doc/source/subcommands/replication-setup.rst
+++ b/doc/source/subcommands/replication-setup.rst
@@ -4,7 +4,7 @@ replication-setup command
 *************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: replication-setup

--- a/doc/source/subcommands/rm.rst
+++ b/doc/source/subcommands/rm.rst
@@ -2,7 +2,7 @@ Rm command
 **********
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: rm

--- a/doc/source/subcommands/sync.rst
+++ b/doc/source/subcommands/sync.rst
@@ -2,7 +2,7 @@ Sync command
 ************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: sync

--- a/doc/source/subcommands/update_bucket.rst
+++ b/doc/source/subcommands/update_bucket.rst
@@ -2,7 +2,7 @@ Update-bucket command
 *********************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: update-bucket

--- a/doc/source/subcommands/update_file_legal_hold.rst
+++ b/doc/source/subcommands/update_file_legal_hold.rst
@@ -2,7 +2,7 @@ Update-file-legal-hold command
 ******************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: update-file-legal-hold

--- a/doc/source/subcommands/update_file_retention.rst
+++ b/doc/source/subcommands/update_file_retention.rst
@@ -2,7 +2,7 @@ Update-file-retention command
 *****************************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: update-file-retention

--- a/doc/source/subcommands/upload_file.rst
+++ b/doc/source/subcommands/upload_file.rst
@@ -2,7 +2,7 @@ Upload-file command
 *******************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: upload-file

--- a/doc/source/subcommands/version.rst
+++ b/doc/source/subcommands/version.rst
@@ -2,7 +2,7 @@ Version command
 ***************
 
 .. argparse::
-   :module: b2.console_tool
+   :module: b2._internal.console_tool
    :func: get_parser
    :prog: b2
    :path: version

--- a/pyinstaller-hooks/hook-b2.py
+++ b/pyinstaller-hooks/hook-b2.py
@@ -13,5 +13,21 @@ from pathlib import Path
 license_file = Path('b2/licenses_output.txt')
 assert license_file.exists()
 datas = [
-    (str(license_file), '.'),
+    # When '.' was provided here, the license file was copied to the root of the executable.
+    # Before ApiVer, it pasted the file to the `b2/` directory.
+    # I have no idea why it worked before or how it works now.
+    # If you mean to debug it in the future, know that `pyinstaller` provides a special
+    # attribute in the `sys` module whenever it runs.
+    #
+    # Example:
+    #     import sys
+    #     if hasattr(sys, '_MEIPASS'):
+    #         self._print(f'{NAME}')
+    #         self._print(f'{sys._MEIPASS}')
+    #         elems = [elem for elem in pathlib.Path(sys._MEIPASS).glob('**/*')]
+    #         self._print(f'{elems}')
+    #
+    # If used at the very start of the `_run` of `Licenses` command, it will print
+    # all the files that were unpacked from the executable.
+    (str(license_file), 'b2/'),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ license = { file = ["requirements-license.txt"] }
 Homepage = "https://github.com/Backblaze/B2_Command_Line_Tool"
 
 [project.scripts]
-b2 = "b2.console_tool:main"
+b2 = "b2._internal.b2v3.__main__:main"
+b2v3 = "b2._internal.b2v3.__main__:main"
+_b2v4 = "b2._internal._b2v4.__main__:main"
 
 [tool.ruff]
 target-version = "py37"  # to be replaced by project:requires-python when we will have that section in here

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,11 @@ setup(
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.
     entry_points={
-        'console_scripts': ['b2=b2.console_tool:main'],
+        'console_scripts':
+            [
+                'b2=b2._internal.b2v3.__main__:main',
+                'b2v3=b2._internal.b2v3.__main__:main',
+                '_b2v4=b2._internal._b2v4.__main__:main',
+            ],
     },
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,75 @@
+######################################################################
+#
+# File: test/conftest.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+import sys
+
+import pytest
+
+
+@pytest.hookimpl
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "cli_version(from_version, to_version): run tests only on certain versions",
+    )
+
+
+@pytest.fixture(scope='session')
+def cli_int_version() -> int:
+    """
+    This should never be called, only provides a placeholder for tests
+    not belonging to neither units nor integrations.
+    """
+    return -1
+
+
+@pytest.fixture(autouse=True)
+def run_on_cli_version_handler(request, cli_int_version):
+    """
+    Auto-fixture that allows skipping tests based on the CLI version.
+
+    Usage:
+        @pytest.mark.cli_version(1, 3)
+        def test_foo():
+            # Test is run only for versions 1 and 3
+            ...
+
+        @pytest.mark.cli_version(from_version=2, to_version=5)
+        def test_bar():
+            # Test is run only for versions 2, 3, 4 and 5
+            ...
+
+    Note that it requires the `cli_int_version` fixture to be defined.
+    Both unit tests and integration tests handle it a little bit different, thus
+    two different fixtures are provided.
+    """
+    node = request.node.get_closest_marker('cli_version')
+    if not node:
+        return
+
+    if not node.args and not node.kwargs:
+        return
+
+    assert cli_int_version >= 0, 'cli_int_version fixture is not defined'
+
+    if node.args:
+        if cli_int_version in node.args:
+            # Run the test.
+            return
+
+    if node.kwargs:
+        from_version = node.kwargs.get('from_version', 0)
+        to_version = node.kwargs.get('to_version', sys.maxsize)
+
+        if from_version <= cli_int_version <= to_version:
+            # Run the test.
+            return
+
+    pytest.skip('Not supported on this CLI version')

--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -58,7 +58,7 @@ from b2sdk.v2.exception import (
     v3BucketIdNotFound,
 )
 
-from b2.console_tool import Command, current_time_millis
+from b2._internal.console_tool import Command, current_time_millis
 
 logger = logging.getLogger(__name__)
 

--- a/test/unit/_cli/test_autocomplete_cache.py
+++ b/test/unit/_cli/test_autocomplete_cache.py
@@ -25,10 +25,10 @@ from typing import Any
 import argcomplete
 import pytest
 
-import b2._cli.argcompleters
-import b2.arg_parser
-import b2.console_tool
-from b2._cli import autocomplete_cache
+import b2._internal._cli.argcompleters
+import b2._internal.arg_parser
+import b2._internal.console_tool
+from b2._internal._cli import autocomplete_cache
 
 # We can't use pytest.mark.skipif to skip forked tests because with pytest-forked,
 # there is an attempt to fork even if the test is marked as skipped.
@@ -81,14 +81,14 @@ def autocomplete_runner(monkeypatch, b2_cli):
             def _get_b2api_for_profile(profile: str):
                 return b2_cli.b2_api
 
-            m.setattr('b2._cli.b2api._get_b2api_for_profile', _get_b2api_for_profile)
+            m.setattr('b2._internal._cli.b2api._get_b2api_for_profile', _get_b2api_for_profile)
             yield
 
     return runner
 
 
 def argcomplete_result():
-    parser = b2.console_tool.B2.create_parser()
+    parser = b2._internal.console_tool.B2.create_parser()
     exit, output = Exit(), io.StringIO()
     argcomplete.autocomplete(parser, exit_method=exit, output_stream=output)
     return exit.code, output.getvalue()
@@ -102,7 +102,7 @@ def cached_complete_result(cache: autocomplete_cache.AutocompleteCache):
 
 def uncached_complete_result(cache: autocomplete_cache.AutocompleteCache):
     exit, output = Exit(), io.StringIO()
-    parser = b2.console_tool.B2.create_parser()
+    parser = b2._internal.console_tool.B2.create_parser()
     cache.cache_and_autocomplete(
         parser, uncached_args={
             'exit_method': exit,

--- a/test/unit/_cli/test_autocomplete_install.py
+++ b/test/unit/_cli/test_autocomplete_install.py
@@ -9,7 +9,7 @@
 ######################################################################
 import pytest
 
-from b2._cli.autocomplete_install import add_or_update_shell_section
+from b2._internal._cli.autocomplete_install import add_or_update_shell_section
 
 section = "test_section"
 managed_by = "pytest"

--- a/test/unit/_cli/test_shell.py
+++ b/test/unit/_cli/test_shell.py
@@ -11,7 +11,7 @@
 import os
 from unittest import mock
 
-from b2._cli import shell
+from b2._internal._cli import shell
 
 
 @mock.patch.dict(os.environ, {"SHELL": "/bin/bash"})

--- a/test/unit/_utils/test_uri.py
+++ b/test/unit/_utils/test_uri.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from b2._utils.uri import B2URI, B2FileIdURI, parse_uri
+from b2._internal._utils.uri import B2URI, B2FileIdURI, parse_uri
 
 
 class TestB2URI:

--- a/test/unit/console_tool/conftest.py
+++ b/test/unit/console_tool/conftest.py
@@ -12,7 +12,7 @@ import sys
 
 import pytest
 
-import b2.console_tool
+import b2._internal.console_tool
 
 
 @pytest.fixture
@@ -27,7 +27,7 @@ def cwd_path(tmp_path):
 @pytest.fixture
 def b2_cli_log_fix(caplog):
     caplog.set_level(0)  # prevent pytest from blocking logs
-    b2.console_tool.logger.setLevel(0)  # reset logger level to default
+    b2._internal.console_tool.logger.setLevel(0)  # reset logger level to default
 
 
 @pytest.fixture

--- a/test/unit/console_tool/test_authorize_account.py
+++ b/test/unit/console_tool/test_authorize_account.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 import pytest
 
-from b2._cli.const import (
+from b2._internal._cli.const import (
     B2_APPLICATION_KEY_ENV_VAR,
     B2_APPLICATION_KEY_ID_ENV_VAR,
     B2_ENVIRONMENT_ENV_VAR,

--- a/test/unit/test_apiver.py
+++ b/test/unit/test_apiver.py
@@ -1,0 +1,67 @@
+######################################################################
+#
+# File: test/unit/test_apiver.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+import unittest
+
+import pytest
+
+
+@pytest.fixture
+def inject_cli_int_version(request, cli_int_version):
+    request.cls.cli_int_version = cli_int_version
+
+
+@pytest.mark.usefixtures('inject_cli_int_version')
+class UnitTestClass(unittest.TestCase):
+    cli_int_version: int
+
+    @pytest.mark.cli_version(to_version=3)
+    def test_passes_below_and_on_v3(self):
+        assert self.cli_int_version <= 3
+
+    @pytest.mark.cli_version(from_version=4)
+    def test_passes_above_and_on_v4(self):
+        assert self.cli_int_version >= 4
+
+    @pytest.mark.cli_version(3)
+    def test_passes_only_on_v3(self):
+        assert self.cli_int_version == 3
+
+    @pytest.mark.cli_version(4)
+    def test_passes_only_on_v4(self):
+        assert self.cli_int_version == 4
+
+    @pytest.mark.cli_version(3, 4)
+    def test_passes_on_both_v3_and_v4(self):
+        assert self.cli_int_version in {3, 4}
+
+
+@pytest.mark.cli_version(to_version=3)
+def test_passes_below_and_on_v3(cli_int_version):
+    assert cli_int_version <= 3
+
+
+@pytest.mark.cli_version(from_version=4)
+def test_passes_above_and_on_v4(cli_int_version):
+    assert cli_int_version >= 4
+
+
+@pytest.mark.cli_version(3)
+def test_passes_only_on_v3(cli_int_version):
+    assert cli_int_version == 3
+
+
+@pytest.mark.cli_version(4)
+def test_passes_only_on_v4(cli_int_version):
+    assert cli_int_version == 4
+
+
+@pytest.mark.cli_version(3, 4)
+def test_passes_on_both_v3_and_v4(cli_int_version):
+    assert cli_int_version in {3, 4}

--- a/test/unit/test_arg_parser.py
+++ b/test/unit/test_arg_parser.py
@@ -11,13 +11,13 @@
 import argparse
 import sys
 
-from b2._cli.arg_parser_types import (
+from b2._internal._cli.arg_parser_types import (
     parse_comma_separated_list,
     parse_millis_from_float_timestamp,
     parse_range,
 )
-from b2.arg_parser import B2ArgumentParser
-from b2.console_tool import B2
+from b2._internal.arg_parser import B2ArgumentParser
+from b2._internal.console_tool import B2
 
 from .test_base import TestBase
 

--- a/test/unit/test_base.py
+++ b/test/unit/test_base.py
@@ -11,9 +11,15 @@
 import re
 import unittest
 from contextlib import contextmanager
+from typing import Type
+
+import pytest
 
 
+@pytest.mark.usefixtures('unit_test_console_tool_class')
 class TestBase(unittest.TestCase):
+    console_tool_class: Type
+
     @contextmanager
     def assertRaises(self, exc, msg=None):
         try:

--- a/test/unit/test_copy.py
+++ b/test/unit/test_copy.py
@@ -19,7 +19,7 @@ from b2sdk.v2 import (
     EncryptionSetting,
 )
 
-from b2.console_tool import CopyFileById
+from b2._internal.console_tool import CopyFileById
 
 from .test_base import TestBase
 

--- a/test/unit/test_represent_file_metadata.py
+++ b/test/unit/test_represent_file_metadata.py
@@ -25,7 +25,7 @@ from b2sdk.v2 import (
     StubAccountInfo,
 )
 
-from b2.console_tool import ConsoleTool, DownloadCommand
+from b2._internal.console_tool import ConsoleTool, DownloadCommand
 
 from .test_base import TestBase
 


### PR DESCRIPTION
- `b2`, `b2v3` and unstable `_b2v4` scripts and binaries are now built.
- Tests are ran against all available versions.
- Both unit and integration tests have the ability to limit versions on which given tests are running.
- `doc` is built only for the latest stable version.
- Implementation moved to `_internal` to discourage people from importing it.