### PR TITLE
Print account info on `b2 authorize-account`

### DIFF
--- a/changelog.d/+authorize-account-output.added.md
+++ b/changelog.d/+authorize-account-output.added.md
@@ -1,0 +1,2 @@
+Print account info if `b2 authorize-account` is successful.
+The output is same as `b2 get-account-info`.

--- a/test/unit/console_tool/test_authorize_account.py
+++ b/test/unit/console_tool/test_authorize_account.py
@@ -53,7 +53,7 @@ def test_authorize_with_good_key(b2_cli, b2_cli_is_authorized_afterwards, comman
     expected_stderr = """
     """
 
-    b2_cli._run_command([command, b2_cli.account_id, b2_cli.master_key], "", expected_stderr, 0)
+    b2_cli._run_command([command, b2_cli.account_id, b2_cli.master_key], None, expected_stderr, 0)
 
     assert b2_cli.account_info.get_account_auth_token() is not None
 
@@ -71,7 +71,7 @@ def test_authorize_using_env_variables(b2_cli):
             B2_APPLICATION_KEY_ENV_VAR: b2_cli.master_key,
         },
     ):
-        b2_cli._run_command(["authorize-account"], "", expected_stderr, 0)
+        b2_cli._run_command(["authorize-account"], None, expected_stderr, 0)
 
     assert b2_cli.account_info.get_account_auth_token() is not None
 
@@ -94,7 +94,7 @@ def test_authorize_towards_realm(
 
     b2_cli._run_command(
         ["authorize-account", *flags, b2_cli.account_id, b2_cli.master_key],
-        "",
+        None,
         expected_stderr,
         0,
     )
@@ -118,7 +118,61 @@ def test_authorize_towards_custom_realm_using_env(b2_cli, b2_cli_is_authorized_a
     ):
         b2_cli._run_command(
             ["authorize-account", b2_cli.account_id, b2_cli.master_key],
-            "",
+            None,
             expected_stderr,
             0,
         )
+
+
+def test_authorize_account_prints_account_info(b2_cli):
+    expected_json = {
+        'accountAuthToken': 'auth_token_0',
+        'accountFilePath': None,
+        'accountId': 'account-0',
+        'allowed':
+            {
+                'bucketId': None,
+                'bucketName': None,
+                'capabilities':
+                    [
+                        'listKeys',
+                        'writeKeys',
+                        'deleteKeys',
+                        'listBuckets',
+                        'listAllBucketNames',
+                        'readBuckets',
+                        'writeBuckets',
+                        'deleteBuckets',
+                        'readBucketEncryption',
+                        'writeBucketEncryption',
+                        'readBucketRetentions',
+                        'writeBucketRetentions',
+                        'readFileRetentions',
+                        'writeFileRetentions',
+                        'readFileLegalHolds',
+                        'writeFileLegalHolds',
+                        'readBucketReplications',
+                        'writeBucketReplications',
+                        'bypassGovernance',
+                        'listFiles',
+                        'readFiles',
+                        'shareFiles',
+                        'writeFiles',
+                        'deleteFiles',
+                    ],
+                'namePrefix': None,
+            },
+        'apiUrl': 'http://api.example.com',
+        'applicationKey': 'masterKey-0',
+        'applicationKeyId': 'account-0',
+        'downloadUrl': 'http://download.example.com',
+        'isMasterKey': True,
+        's3endpoint': 'http://s3.api.example.com'
+    }
+
+    b2_cli._run_command(
+        ['authorize-account', b2_cli.account_id, b2_cli.master_key],
+        expected_stderr='',
+        expected_status=0,
+        expected_json_in_stdout=expected_json,
+    )

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -272,7 +272,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         # Authorize with the key
         self._run_command(
             ['authorize-account', 'appKeyId0', 'appKey0'],
-            '',
+            None,
             '',
             0,
         )
@@ -418,7 +418,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         # Authorize with the key
         self._run_command(
             ['authorize-account', 'appKeyId0', 'appKey0'],
-            '',
+            None,
             '',
             0,
         )
@@ -670,7 +670,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         self._run_command(['list-keys', '--long'], expected_list_keys_out_long, '', 0)
 
         # authorize and make calls using application key with no restrictions
-        self._run_command(['authorize-account', 'appKeyId0', 'appKey0'], '', '', 0)
+        self._run_command(['authorize-account', 'appKeyId0', 'appKey0'], None, '', 0)
         self._run_command(
             ['list-buckets'],
             'bucket_0  allPublic   my-bucket-a\nbucket_2  allPublic   my-bucket-c\n', '', 0
@@ -693,7 +693,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         self._run_command(['get-bucket', 'my-bucket-a'], expected_json_in_stdout=expected_json)
 
         # authorize and make calls using an application key with bucket restrictions
-        self._run_command(['authorize-account', 'appKeyId1', 'appKey1'], '', '', 0)
+        self._run_command(['authorize-account', 'appKeyId1', 'appKey1'], None, '', 0)
 
         self._run_command(
             ['list-buckets'], '', 'ERROR: Application key is restricted to bucket: my-bucket-a\n', 1


### PR DESCRIPTION
Currently, the `b2 authorize-account` command does not output anything if the command is successful. To get the account info, you need to invoke another command (`b2 get-account-info`).

This PR prints the account info after the `b2 authorize-account` command. The output is similar to `b2 get-account-info`.