### PR TITLE
Don't show full binary path in help message

### DIFF
--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -4006,7 +4006,7 @@ class ConsoleTool:
 
     def run_command(self, argv):
         signal.signal(signal.SIGINT, keyboard_interrupt_handler)
-        parser = B2.create_parser(name=argv[0])
+        parser = B2.create_parser(name=NAME)
         AUTOCOMPLETE.cache_and_autocomplete(parser)
         args = parser.parse_args(argv[1:])
         self._setup_logging(args, argv)


### PR DESCRIPTION
Without this change:

```sh
root@dc7d16c9b121:/usr/local/lib/python3.11/site-packages/b2# b2 --help
/usr/local/bin/b2 [-h] [--help-all]
```

With this change:

```sh
root@dc7d16c9b121:/usr/local/lib/python3.11/site-packages/b2# b2 --help
b2 [-h] [--help-all]
```