### PR TITLE
Use `InMemoryAccountInfo` when using env vars for authentication

### DIFF
--- a/b2/_internal/_cli/b2api.py
+++ b/b2/_internal/_cli/b2api.py
@@ -19,11 +19,22 @@ from b2sdk.v2 import (
     InMemoryCache,
     SqliteAccountInfo,
 )
+from b2sdk.v2.exception import MissingAccountData
 
 from b2._internal._cli.const import B2_USER_AGENT_APPEND_ENV_VAR
 
 
-def _get_b2api_for_profile(profile: Optional[str] = None, **kwargs) -> B2Api:
+def _get_b2api_for_profile(
+    profile: Optional[str] = None,
+    raise_if_does_not_exist: bool = False,
+    **kwargs,
+) -> B2Api:
+
+    if raise_if_does_not_exist:
+        account_info_file = SqliteAccountInfo._get_user_account_info_path(profile=profile)
+        if not os.path.exists(account_info_file):
+            raise MissingAccountData(account_info_file)
+
     account_info = SqliteAccountInfo(profile=profile)
     b2api = B2Api(
         api_config=_get_b2httpapiconfig(),

--- a/b2/_internal/_cli/b2api.py
+++ b/b2/_internal/_cli/b2api.py
@@ -15,6 +15,8 @@ from b2sdk.v2 import (
     AuthInfoCache,
     B2Api,
     B2HttpApiConfig,
+    InMemoryAccountInfo,
+    InMemoryCache,
     SqliteAccountInfo,
 )
 
@@ -44,6 +46,10 @@ def _get_b2api_for_profile(profile: Optional[str] = None, **kwargs) -> B2Api:
         b2http.TRY_COUNT_HEAD = 2
         b2http.TRY_COUNT_OTHER = 2
     return b2api
+
+
+def _get_inmemory_b2api(**kwargs) -> B2Api:
+    return B2Api(InMemoryAccountInfo(), cache=InMemoryCache(), **kwargs)
 
 
 def _get_b2httpapiconfig():

--- a/b2/_internal/_cli/b2args.py
+++ b/b2/_internal/_cli/b2args.py
@@ -12,9 +12,15 @@ Utility functions for adding b2-specific arguments to an argparse parser.
 """
 import argparse
 import functools
+from os import environ
+from typing import Optional
 
 from b2._internal._cli.arg_parser_types import wrap_with_argument_type_error
 from b2._internal._cli.argcompleters import b2uri_file_completer
+from b2._internal._cli.const import (
+    B2_APPLICATION_KEY_ENV_VAR,
+    B2_APPLICATION_KEY_ID_ENV_VAR,
+)
 from b2._internal._utils.uri import B2URI, B2URIBase, parse_b2_uri
 
 
@@ -76,3 +82,7 @@ def add_b2id_or_file_like_b2_uri_argument(parser: argparse.ArgumentParser, name=
         type=B2ID_OR_FILE_LIKE_B2_URI_ARG_TYPE,
         help="B2 URI pointing to a file, e.g. b2://yourBucket/file.txt or b2id://fileId",
     ).completer = b2uri_file_completer
+
+
+def get_keyid_and_key_from_env_vars() -> tuple[Optional[str], Optional[str]]:
+    return environ.get(B2_APPLICATION_KEY_ID_ENV_VAR), environ.get(B2_APPLICATION_KEY_ENV_VAR)

--- a/b2/_internal/_cli/b2args.py
+++ b/b2/_internal/_cli/b2args.py
@@ -13,7 +13,7 @@ Utility functions for adding b2-specific arguments to an argparse parser.
 import argparse
 import functools
 from os import environ
-from typing import Optional
+from typing import Optional, Tuple
 
 from b2._internal._cli.arg_parser_types import wrap_with_argument_type_error
 from b2._internal._cli.argcompleters import b2uri_file_completer
@@ -84,5 +84,5 @@ def add_b2id_or_file_like_b2_uri_argument(parser: argparse.ArgumentParser, name=
     ).completer = b2uri_file_completer
 
 
-def get_keyid_and_key_from_env_vars() -> tuple[Optional[str], Optional[str]]:
+def get_keyid_and_key_from_env_vars() -> Tuple[Optional[str], Optional[str]]:
     return environ.get(B2_APPLICATION_KEY_ID_ENV_VAR), environ.get(B2_APPLICATION_KEY_ENV_VAR)

--- a/b2/_internal/b2v3/registry.py
+++ b/b2/_internal/b2v3/registry.py
@@ -10,10 +10,20 @@
 
 # ruff: noqa: F405
 from b2._internal._b2v4.registry import *  # noqa
+from b2._internal._cli.b2api import _get_b2api_for_profile
 from b2._internal.arg_parser import enable_camel_case_arguments
 from .rm import Rm
 
 enable_camel_case_arguments()
+
+
+class ConsoleTool(ConsoleTool):
+    # same as original console tool, but does not use InMemoryAccountInfo and InMemoryCache
+    # when auth env vars are used
+
+    @classmethod
+    def _initialize_b2_api(cls, args: argparse.Namespace, kwargs: dict) -> B2Api:
+        return _get_b2api_for_profile(profile=args.profile, **kwargs)
 
 
 class Ls(B2URIBucketNFolderNameArgMixin, BaseLs):

--- a/b2/_internal/b2v3/registry.py
+++ b/b2/_internal/b2v3/registry.py
@@ -26,6 +26,24 @@ class ConsoleTool(ConsoleTool):
         return _get_b2api_for_profile(profile=args.profile, **kwargs)
 
 
+def main() -> None:
+    # this is a copy of v4 `main()` but with custom console tool class
+
+    ct = ConsoleTool(stdout=sys.stdout, stderr=sys.stderr)
+    exit_status = ct.run_command(sys.argv)
+    logger.info('\\\\ %s %s %s //', SEPARATOR, ('exit=%s' % exit_status).center(8), SEPARATOR)
+
+    # I haven't tracked down the root cause yet, but in Python 2.7, the futures
+    # packages is hanging on exit sometimes, waiting for a thread to finish.
+    # This happens when using sync to upload files.
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    logging.shutdown()
+
+    os._exit(exit_status)
+
+
 class Ls(B2URIBucketNFolderNameArgMixin, BaseLs):
     """
     {BASELS}

--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -4224,12 +4224,7 @@ class ConsoleTool:
         with suppress(AttributeError):
             kwargs['max_download_streams_per_file'] = args.max_download_streams_per_file
 
-        if all(get_keyid_and_key_from_env_vars()
-              ) and args.command_class not in (AuthorizeAccount, ClearAccount):
-            # when user specifies keys via env variables, we switch to in-memory account info
-            self.api = _get_inmemory_b2api(**kwargs)
-        else:
-            self.api = _get_b2api_for_profile(profile=args.profile, **kwargs)
+        self.api = self._initialize_b2_api(args=args, kwargs=kwargs)
 
         b2_command = B2(self)
         command_class = b2_command.run(args)
@@ -4263,6 +4258,15 @@ class ConsoleTool:
         except Exception:
             logger.exception('ConsoleTool unexpected exception')
             raise
+
+    @classmethod
+    def _initialize_b2_api(cls, args: argparse.Namespace, kwargs: dict) -> B2Api:
+        if all(get_keyid_and_key_from_env_vars()
+              ) and args.command_class not in (AuthorizeAccount, ClearAccount):
+            # when user specifies keys via env variables, we switch to in-memory account info
+            return _get_inmemory_b2api(**kwargs)
+
+        return _get_b2api_for_profile(profile=args.profile, **kwargs)
 
     def authorize_from_env(self, command_class):
         if not command_class.REQUIRES_AUTH:

--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -4265,7 +4265,9 @@ class ConsoleTool:
 
         # here we initialize regular b2 api on disk, and check whether it matches
         # the keys from env vars; if they indeed match then there's no need to
-        # initialize in-memory account info cause it's already stored on disk
+        # initialize in-memory account info cause it's already stored on disk;
+        # beware that this has side effect of creating an empty account info file
+        # if it didn't exist before
         b2_api = _get_b2api_for_profile(profile=args.profile, **kwargs)
 
         key_id, key = get_keyid_and_key_from_env_vars()

--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -130,10 +130,11 @@ from b2._internal._cli.autocomplete_install import (
     AutocompleteInstallError,
     autocomplete_install,
 )
-from b2._internal._cli.b2api import _get_b2api_for_profile
+from b2._internal._cli.b2api import _get_b2api_for_profile, _get_inmemory_b2api
 from b2._internal._cli.b2args import (
     add_b2id_or_b2_uri_argument,
     add_b2id_or_file_like_b2_uri_argument,
+    get_keyid_and_key_from_env_vars,
 )
 from b2._internal._cli.const import (
     B2_APPLICATION_KEY_ENV_VAR,
@@ -4179,11 +4180,11 @@ class ConsoleTool:
     Implements the commands available in the B2 command-line tool
     using the B2Api library.
 
-    Uses a ``b2sdk.SqlitedAccountInfo`` object to keep account data between runs.
+    Uses a ``b2sdk.SqlitedAccountInfo`` object to keep account data between runs
+    (unless authorization is performed via environment variables).
     """
 
-    def __init__(self, b2_api: B2Api | None, stdout, stderr):
-        self.api = b2_api
+    def __init__(self, stdout, stderr):
         self.stdout = stdout
         self.stderr = stderr
         self.b2_binary_name = 'b2'
@@ -4214,32 +4215,20 @@ class ConsoleTool:
             # in case any control characters slip through escaping, just delete them
             self.stdout = NoControlCharactersStdout(self.stdout)
             self.stderr = NoControlCharactersStdout(self.stderr)
-        if self.api:
-            if (
-                args.profile or getattr(args, 'write_buffer_size', None) or
-                getattr(args, 'skip_hash_verification', None) or
-                getattr(args, 'max_download_streams_per_file', None)
-            ):
-                self._print_stderr(
-                    'ERROR: cannot change configuration on already initialized object'
-                )
-                return 1
 
+        kwargs = {}
+        with suppress(AttributeError):
+            kwargs['save_to_buffer_size'] = args.write_buffer_size
+        with suppress(AttributeError):
+            kwargs['check_download_hash'] = not args.skip_hash_verification
+        with suppress(AttributeError):
+            kwargs['max_download_streams_per_file'] = args.max_download_streams_per_file
+
+        if all(get_keyid_and_key_from_env_vars()) and args.command_class not in (AuthorizeAccount, ClearAccount):
+            # when user specifies keys via env variables, we switch to in-memory account info
+            self.api = _get_inmemory_b2api(**kwargs)
         else:
-            kwargs = {
-                'profile': args.profile,
-            }
-
-            if 'write_buffer_size' in args:
-                kwargs['save_to_buffer_size'] = args.write_buffer_size
-
-            if 'skip_hash_verification' in args:
-                kwargs['check_download_hash'] = not args.skip_hash_verification
-
-            if 'max_download_streams_per_file' in args:
-                kwargs['max_download_streams_per_file'] = args.max_download_streams_per_file
-
-            self.api = _get_b2api_for_profile(**kwargs)
+            self.api = _get_b2api_for_profile(profile=args.profile, **kwargs)
 
         b2_command = B2(self)
         command_class = b2_command.run(args)
@@ -4278,8 +4267,7 @@ class ConsoleTool:
         if not command_class.REQUIRES_AUTH:
             return 0
 
-        key_id = os.environ.get(B2_APPLICATION_KEY_ID_ENV_VAR)
-        key = os.environ.get(B2_APPLICATION_KEY_ENV_VAR)
+        key_id, key = get_keyid_and_key_from_env_vars()
 
         if key_id is None and key is None:
             return 0
@@ -4349,7 +4337,7 @@ get_parser = functools.partial(B2.create_parser, for_docs=True)
 
 
 def main():
-    ct = ConsoleTool(b2_api=None, stdout=sys.stdout, stderr=sys.stderr)
+    ct = ConsoleTool(stdout=sys.stdout, stderr=sys.stderr)
     exit_status = ct.run_command(sys.argv)
     logger.info('\\\\ %s %s %s //', SEPARATOR, ('exit=%s' % exit_status).center(8), SEPARATOR)
 

--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -4224,7 +4224,8 @@ class ConsoleTool:
         with suppress(AttributeError):
             kwargs['max_download_streams_per_file'] = args.max_download_streams_per_file
 
-        if all(get_keyid_and_key_from_env_vars()) and args.command_class not in (AuthorizeAccount, ClearAccount):
+        if all(get_keyid_and_key_from_env_vars()
+              ) and args.command_class not in (AuthorizeAccount, ClearAccount):
             # when user specifies keys via env variables, we switch to in-memory account info
             self.api = _get_inmemory_b2api(**kwargs)
         else:

--- a/changelog.d/+not-saving-auth-data-when-env-vars.fixed.md
+++ b/changelog.d/+not-saving-auth-data-when-env-vars.fixed.md
@@ -1,1 +1,1 @@
-Fix persisting credentials on disk even if environment variables were used for authentication.
+Don't persist credentials provided in the Enviornment variables in any command other than `authorize-account`.

--- a/changelog.d/+not-saving-auth-data-when-env-vars.fixed.md
+++ b/changelog.d/+not-saving-auth-data-when-env-vars.fixed.md
@@ -1,0 +1,1 @@
+Fix persisting credentials on disk even if environment variables were used for authentication.

--- a/changelog.d/+not-saving-auth-data-when-env-vars.fixed.md
+++ b/changelog.d/+not-saving-auth-data-when-env-vars.fixed.md
@@ -1,1 +1,1 @@
-Don't persist credentials provided in the Enviornment variables in any command other than `authorize-account`.
+Don't persist credentials provided in the Enviornment variables in any command other than `authorize-account` when using `b2v4`.

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -100,13 +100,18 @@ def get_raw_cli_int_version(config) -> int | None:
     return None
 
 
-@pytest.fixture(scope='session')
-def apiver(request):
-    return f"v{get_cli_int_version(request.config)}"
-
-
 def get_cli_int_version(config) -> int:
     return get_raw_cli_int_version(config) or get_int_version(LATEST_STABLE_VERSION)
+
+
+@pytest.fixture(scope='session')
+def apiver_int(request):
+    return get_cli_int_version(request.config)
+
+
+@pytest.fixture(scope='session')
+def apiver(apiver_int):
+    return f"v{apiver_int}"
 
 
 @pytest.hookimpl

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -205,11 +205,12 @@ def monkeysession():
 
 
 @pytest.fixture(scope='session', autouse=True)
-def auto_change_account_info_dir(monkeysession) -> dir:
+def auto_change_account_info_dir(monkeysession) -> str:
     """
     Automatically for the whole testing:
     1) temporary remove B2_APPLICATION_KEY and B2_APPLICATION_KEY_ID from environment
     2) create a temporary directory for storing account info database
+    3) set B2_ACCOUNT_INFO_ENV_VAR to point to the temporary account info file
     """
 
     monkeysession.delenv('B2_APPLICATION_KEY_ID', raising=False)
@@ -267,6 +268,17 @@ def b2_tool(global_b2_tool):
     """Automatically reauthorized b2_tool for each test (without check)"""
     global_b2_tool.reauthorize(check_key_capabilities=False)
     return global_b2_tool
+
+
+@pytest.fixture
+def account_info_file() -> pathlib.Path:
+    return pathlib.Path(os.environ[B2_ACCOUNT_INFO_ENV_VAR]).expanduser()
+
+
+@pytest.fixture
+def no_account_info_file(account_info_file):
+    """Remove account info file to deauthorize b2_tool"""
+    yield account_info_file.unlink()
 
 
 @pytest.fixture

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -276,12 +276,6 @@ def account_info_file() -> pathlib.Path:
 
 
 @pytest.fixture
-def no_account_info_file(account_info_file):
-    """Remove account info file to deauthorize b2_tool"""
-    yield account_info_file.unlink()
-
-
-@pytest.fixture
 def schedule_bucket_cleanup(global_b2_tool):
     """
     Explicitly ask for buckets cleanup after the test

--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from os import environ, linesep, path
 from pathlib import Path
-from tempfile import gettempdir, mkdtemp, mktemp
+from tempfile import mkdtemp, mktemp
 
 import backoff
 from b2sdk.v2 import (
@@ -349,7 +349,7 @@ class EnvVarTestContext:
 
     def __enter__(self):
         src = self.account_info_file_name
-        dst = path.join(gettempdir(), 'b2_account_info')
+        dst = path.join(mkdtemp(), 'b2_account_info')
         shutil.copyfile(src, dst)
         shutil.move(src, src + self.suffix)
         environ[self.ENV_VAR] = dst

--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -27,7 +27,7 @@ import time
 import warnings
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from os import environ, linesep, path
+from os import environ, linesep
 from pathlib import Path
 from tempfile import mkdtemp, mktemp
 
@@ -47,7 +47,6 @@ from b2sdk.v2 import (
     InMemoryCache,
     LegalHold,
     RetentionMode,
-    SqliteAccountInfo,
     fix_windows_path_limit,
 )
 from b2sdk.v2.exception import (
@@ -336,33 +335,6 @@ class StringReader:
             self.string = str(e)
 
 
-class EnvVarTestContext:
-    """
-    Establish config for environment variable test.
-    Copy the B2 credential file and rename the existing copy
-    """
-    ENV_VAR = 'B2_ACCOUNT_INFO'
-
-    def __init__(self, account_info_file_name: str):
-        self.account_info_file_name = account_info_file_name
-        self.suffix = ''.join(RNG.choice('abcdefghijklmnopqrstuvwxyz0123456789') for _ in range(7))
-
-    def __enter__(self):
-        src = self.account_info_file_name
-        dst = path.join(mkdtemp(), 'b2_account_info')
-        shutil.copyfile(src, dst)
-        shutil.move(src, src + self.suffix)
-        environ[self.ENV_VAR] = dst
-        return dst
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        os.remove(environ.get(self.ENV_VAR))
-        fname = self.account_info_file_name
-        shutil.move(fname + self.suffix, fname)
-        if environ.get(self.ENV_VAR) is not None:
-            del environ[self.ENV_VAR]
-
-
 def should_equal(expected, actual):
     print('  expected:')
     print_json_indented(expected)
@@ -406,7 +378,6 @@ class CommandLine:
         self.realm = realm
         self.bucket_name_prefix = bucket_name_prefix
         self.env_file_cmd_placeholder = env_file_cmd_placeholder
-        self.env_var_test_context = EnvVarTestContext(SqliteAccountInfo().filename)
         self.api_wrapper = api_wrapper
         self.b2_uri_args = b2_uri_args
 

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -558,7 +558,7 @@ def test_account(b2_tool, cli_version):
             ['create-bucket', bucket_name, 'allPrivate', *b2_tool.get_bucket_info_args()]
         )
         b2_tool.should_succeed(['delete-bucket', bucket_name])
-        assert os.path.exists(new_creds), 'sqlite file not created'
+        assert not os.path.exists(new_creds), 'sqlite file was created'
 
         os.environ.pop('B2_APPLICATION_KEY')
         os.environ.pop('B2_APPLICATION_KEY_ID')

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -647,14 +647,13 @@ def test_account(b2_tool, cli_version, apiver_int, monkeypatch):
         )
         b2_tool.should_succeed(['delete-bucket', bucket_name])
 
-        assert os.path.exists(account_info_file_path), 'sqlite file was not created'
-        account_info = SqliteAccountInfo(account_info_file_path)
         if apiver_int >= 4:
-            with pytest.raises(MissingAccountData):
-                account_info.get_application_key_id()
-            with pytest.raises(MissingAccountData):
-                account_info.get_application_key()
+            assert not os.path.exists(
+                account_info_file_path
+            ), 'sqlite file was created while it shouldn\'t'
         else:
+            assert os.path.exists(account_info_file_path), 'sqlite file was not created'
+            account_info = SqliteAccountInfo(account_info_file_path)
             assert account_info.get_application_key_id() == os.environ['B2_TEST_APPLICATION_KEY_ID']
             assert account_info.get_application_key() == os.environ['B2_TEST_APPLICATION_KEY']
 

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -102,10 +102,13 @@ def test_authorize_account_via_env_vars_saving_credentials(
     assert B2_APPLICATION_KEY_ID_ENV_VAR not in os.environ
     assert B2_APPLICATION_KEY_ENV_VAR not in os.environ
 
-    b2_tool.should_succeed(['authorize-account'], additional_env={
-        B2_APPLICATION_KEY_ID_ENV_VAR: application_key_id,
-        B2_APPLICATION_KEY_ENV_VAR: application_key,
-    })
+    b2_tool.should_succeed(
+        ['authorize-account'],
+        additional_env={
+            B2_APPLICATION_KEY_ID_ENV_VAR: application_key_id,
+            B2_APPLICATION_KEY_ENV_VAR: application_key,
+        }
+    )
 
     assert account_info_file.exists()
     account_info = SqliteAccountInfo()
@@ -129,10 +132,13 @@ def test_clear_account_with_env_vars(
     assert account_info.get_application_key() == application_key
     assert account_info.get_application_key_id() == application_key_id
 
-    b2_tool.should_succeed(['clear-account'], additional_env={
-        B2_APPLICATION_KEY_ID_ENV_VAR: application_key_id,
-        B2_APPLICATION_KEY_ENV_VAR: application_key,
-    })
+    b2_tool.should_succeed(
+        ['clear-account'],
+        additional_env={
+            B2_APPLICATION_KEY_ID_ENV_VAR: application_key_id,
+            B2_APPLICATION_KEY_ENV_VAR: application_key,
+        }
+    )
 
     assert account_info_file.exists()
     account_info = SqliteAccountInfo()
@@ -159,10 +165,13 @@ def test_command_with_env_vars_not_saving_credentials(
     assert B2_APPLICATION_KEY_ID_ENV_VAR not in os.environ
     assert B2_APPLICATION_KEY_ENV_VAR not in os.environ
 
-    b2_tool.should_succeed(['ls', f"b2id://{uploaded_sample_file['fileId']}"], additional_env={
-        B2_APPLICATION_KEY_ID_ENV_VAR: application_key_id,
-        B2_APPLICATION_KEY_ENV_VAR: application_key,
-    })
+    b2_tool.should_succeed(
+        ['ls', f"b2id://{uploaded_sample_file['fileId']}"],
+        additional_env={
+            B2_APPLICATION_KEY_ID_ENV_VAR: application_key_id,
+            B2_APPLICATION_KEY_ENV_VAR: application_key,
+        }
+    )
 
     assert not account_info_file.exists()
 

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -67,14 +67,14 @@ def test_authorize_account_via_params_saving_credentials(
     application_key,
     application_key_id,
     account_info_file,
-    no_account_info_file,
 ):
     """
     When calling `authorize-account` and passing credentials as params,
     we want the credentials to be saved.
     """
 
-    assert not account_info_file.exists()
+    b2_tool.should_succeed(['clear-account'])
+
     assert B2_APPLICATION_KEY_ID_ENV_VAR not in os.environ
     assert B2_APPLICATION_KEY_ENV_VAR not in os.environ
 
@@ -91,14 +91,14 @@ def test_authorize_account_via_env_vars_saving_credentials(
     application_key,
     application_key_id,
     account_info_file,
-    no_account_info_file,
 ):
     """
     When calling `authorize-account` and passing credentials
     via env vars, we still want the credentials to be saved.
     """
 
-    assert not account_info_file.exists()
+    b2_tool.should_succeed(['clear-account'])
+
     assert B2_APPLICATION_KEY_ID_ENV_VAR not in os.environ
     assert B2_APPLICATION_KEY_ENV_VAR not in os.environ
 
@@ -154,7 +154,6 @@ def test_command_with_env_vars_not_saving_credentials(
     application_key_id,
     account_info_file,
     bucket_name,
-    no_account_info_file,
     b2_uri_args,
 ):
     """
@@ -162,7 +161,8 @@ def test_command_with_env_vars_not_saving_credentials(
     via env vars, we don't want them to be saved.
     """
 
-    assert not account_info_file.exists()
+    b2_tool.should_succeed(['clear-account'])
+
     assert B2_APPLICATION_KEY_ID_ENV_VAR not in os.environ
     assert B2_APPLICATION_KEY_ENV_VAR not in os.environ
 
@@ -174,7 +174,12 @@ def test_command_with_env_vars_not_saving_credentials(
         }
     )
 
-    assert not account_info_file.exists()
+    assert account_info_file.exists()
+    account_info = SqliteAccountInfo()
+    with pytest.raises(MissingAccountData):
+        account_info.get_application_key()
+    with pytest.raises(MissingAccountData):
+        account_info.get_application_key_id()
 
 
 @pytest.fixture

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -153,8 +153,9 @@ def test_command_with_env_vars_not_saving_credentials(
     application_key,
     application_key_id,
     account_info_file,
-    uploaded_sample_file,
+    bucket_name,
     no_account_info_file,
+    b2_uri_args,
 ):
     """
     When calling any command other then `authorize-account` and passing credentials
@@ -166,7 +167,7 @@ def test_command_with_env_vars_not_saving_credentials(
     assert B2_APPLICATION_KEY_ENV_VAR not in os.environ
 
     b2_tool.should_succeed(
-        ['ls', f"b2id://{uploaded_sample_file['fileId']}"],
+        ['ls', '--long', *b2_uri_args(bucket_name)],
         additional_env={
             B2_APPLICATION_KEY_ID_ENV_VAR: application_key_id,
             B2_APPLICATION_KEY_ENV_VAR: application_key,

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -148,6 +148,40 @@ def test_clear_account_with_env_vars(
         account_info.get_application_key_id()
 
 
+@pytest.mark.apiver(to_ver=3)
+def test_command_with_env_vars_saving_credentials(
+    b2_tool,
+    application_key,
+    application_key_id,
+    account_info_file,
+    bucket_name,
+    b2_uri_args,
+):
+    """
+    When calling any command other then `authorize-account` and passing credentials
+    via env vars, we don't want them to be saved.
+    """
+
+    b2_tool.should_succeed(['clear-account'])
+
+    assert B2_APPLICATION_KEY_ID_ENV_VAR not in os.environ
+    assert B2_APPLICATION_KEY_ENV_VAR not in os.environ
+
+    b2_tool.should_succeed(
+        ['ls', '--long', *b2_uri_args(bucket_name)],
+        additional_env={
+            B2_APPLICATION_KEY_ID_ENV_VAR: application_key_id,
+            B2_APPLICATION_KEY_ENV_VAR: application_key,
+        }
+    )
+
+    assert account_info_file.exists()
+    account_info = SqliteAccountInfo()
+    assert account_info.get_application_key() == application_key
+    assert account_info.get_application_key_id() == application_key_id
+
+
+@pytest.mark.apiver(from_ver=4)
 def test_command_with_env_vars_not_saving_credentials(
     b2_tool,
     application_key,

--- a/test/unit/console_tool/test_download_file.py
+++ b/test/unit/console_tool/test_download_file.py
@@ -205,4 +205,4 @@ def test__download_file__threads(b2_cli, local_file, uploaded_file, tmp_path):
     )
 
     assert output_path.read_text() == uploaded_file['content']
-    assert b2_cli.b2_api.services.download_manager.get_thread_pool_size() == num_threads
+    assert b2_cli.console_tool.api.services.download_manager.get_thread_pool_size() == num_threads

--- a/test/unit/console_tool/test_upload_file.py
+++ b/test/unit/console_tool/test_upload_file.py
@@ -155,4 +155,4 @@ def test_upload_file__threads_setting(b2_cli, bucket, tmp_path):
         remove_version=True,
     )
 
-    assert b2_cli.b2_api.services.upload_manager.get_thread_pool_size() == num_threads
+    assert b2_cli.console_tool.api.services.upload_manager.get_thread_pool_size() == num_threads

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -102,8 +102,7 @@ class BaseConsoleToolTest(TestBase):
         success, but ignoring the stdout.
         """
         stdout, stderr = self._get_stdouterr()
-        actual_status = self.console_tool_class(stdout,
-                                                stderr).run_command(['b2'] + argv)
+        actual_status = self.console_tool_class(stdout, stderr).run_command(['b2'] + argv)
         actual_stderr = self._trim_trailing_spaces(stderr.getvalue())
 
         if actual_stderr != '':
@@ -2485,9 +2484,14 @@ class TestConsoleTool(BaseConsoleToolTest):
         os.environ[B2_APPLICATION_KEY_ENV_VAR] = self.master_key
 
         command = [
-            'b2', 'download-file-by-id', 'dummy-id', 'dummy-local-file-name',
-            '--write-buffer-size', '123',
-            '--max-download-streams-per-file', '5',
+            'b2',
+            'download-file-by-id',
+            'dummy-id',
+            'dummy-local-file-name',
+            '--write-buffer-size',
+            '123',
+            '--max-download-streams-per-file',
+            '5',
             '--skip-hash-verification',
         ]
 

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -12,6 +12,7 @@ import json
 import os
 import pathlib
 import re
+from functools import lru_cache
 from io import StringIO
 from itertools import chain, product
 from test.helpers import skip_on_windows
@@ -63,6 +64,7 @@ class BaseConsoleToolTest(TestBase):
         self.raw_simulator = RawSimulator()
         self.api_config = B2HttpApiConfig(_raw_api_class=lambda *args, **kwargs: self.raw_simulator)
 
+        @lru_cache(maxsize=None)
         def _get_b2api(**kwargs) -> B2Api:
             kwargs.pop('profile', None)
             return B2Api(
@@ -2513,7 +2515,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         )
         assert parallel_strategy.max_streams == 5
 
-    @pytest.mark.cli_version(from_version=4)
+    @pytest.mark.apiver(from_ver=4)
     def test_ls_b2id(self):
         self._authorize_account()
         self._create_my_bucket()

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -217,13 +217,15 @@ class BaseConsoleToolTest(TestBase):
         format_vars.
 
         The ConsoleTool is stateless, so we can make a new one for each
-        call, with a fresh stdout and stderr
+        call, with a fresh stdout and stderr. However, last instance of ConsoleTool
+        is stored in `self.console_tool`, may be handy for testing internals
+        of the tool after last command invocation.
         """
         expected_stderr = self._normalize_expected_output(expected_stderr, format_vars)
         stdout, stderr = self._get_stdouterr()
-        console_tool = self.console_tool_class(stdout, stderr)
+        self.console_tool = self.console_tool_class(stdout, stderr)
         try:
-            actual_status = console_tool.run_command(['b2'] + argv)
+            actual_status = self.console_tool.run_command(['b2'] + argv)
         except SystemExit as e:
             actual_status = e.code
 

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -74,9 +74,7 @@ class BaseConsoleToolTest(TestBase):
                 **kwargs,
             )
 
-        self.mp = pytest.MonkeyPatch()
-        self.mp.setattr('b2._internal.console_tool._get_b2api_for_profile', _get_b2api)
-        self.mp.setattr('b2._internal.console_tool._get_inmemory_b2api', _get_b2api)
+        self.console_tool_class._initialize_b2_api = lambda cls, args, kwargs: _get_b2api(**kwargs)
 
         self.b2_api = _get_b2api()
         self.raw_api = self.b2_api.session.raw_api
@@ -88,10 +86,6 @@ class BaseConsoleToolTest(TestBase):
             B2_ENVIRONMENT_ENV_VAR,
         ]:
             os.environ.pop(env_var_name, None)
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        self.mp.undo()
 
     def _get_stdouterr(self):
         stdout = StringIO()

--- a/test/unit/test_represent_file_metadata.py
+++ b/test/unit/test_represent_file_metadata.py
@@ -10,6 +10,7 @@
 
 from io import StringIO
 
+import pytest
 from b2sdk.v2 import (
     SSE_B2_AES,
     B2Api,
@@ -24,7 +25,6 @@ from b2sdk.v2 import (
     RetentionMode,
     StubAccountInfo,
 )
-import pytest
 
 from b2._internal.console_tool import ConsoleTool, DownloadCommand
 

--- a/test/unit/test_represent_file_metadata.py
+++ b/test/unit/test_represent_file_metadata.py
@@ -24,6 +24,7 @@ from b2sdk.v2 import (
     RetentionMode,
     StubAccountInfo,
 )
+import pytest
 
 from b2._internal.console_tool import ConsoleTool, DownloadCommand
 
@@ -60,9 +61,21 @@ class TestReprentFileMetadata(TestBase):
             'production', self.restricted_key_id, self.restricted_key
         )
 
+        def _get_b2api(**kwargs) -> B2Api:
+            kwargs.pop('profile', None)
+            return self.master_b2_api
+
+        self.mp = pytest.MonkeyPatch()
+        self.mp.setattr('b2._internal.console_tool._get_b2api_for_profile', _get_b2api)
+        self.mp.setattr('b2._internal.console_tool._get_inmemory_b2api', _get_b2api)
+
         self.stdout = StringIO()
         self.stderr = StringIO()
-        self.console_tool = ConsoleTool(self.master_b2_api, self.stdout, self.stderr)
+        self.console_tool = ConsoleTool(self.stdout, self.stderr)
+
+    def tearDown(self):
+        self.mp.undo()
+        super().tearDown()
 
     def assertRetentionRepr(self, file_id: str, api: B2Api, expected_repr: str):
         file_version = api.get_file_info(file_id)


### PR DESCRIPTION
Re https://github.com/Backblaze/B2_Command_Line_Tool/issues/894

**Current behavior:**
When users use env vars for authenticating in B2, those credentials are stored in `~/.b2_account_info` file which is unexpected by users and exposes B2 secrets to everyone who can read the file.

**New behavior (CLI >=v4 only):**
If user uses env vars for authentication, console tool uses `InMemoryAccountInfo` for storing account info and `InMemoryCache` for caching data.

Exception: when user calls `authorize-account` or `clear-account` commands, they store (or clear) credentials *on disk* even if "env vars authorization" is used.

--

This PR also removes `b2_api` parameter from `ConsoleTool` class init method. It was used only in tests and allowed passing mocked `B2Api` instance, however it added complexity to production code in case when special parameters were passed (like `--max_download_streams_per_file`): those parameters should be passed to `B2Api` during initialization, but `ConsoleTool` received already initialized mocked `B2Api` instance and thus those parameters couldn't be applied.

This is fixed by delegating `B2Api` initialization to `ConsoleTool` entirely, and for tests we use monkeypatching which substitutes few functions used to initialize `B2Api` inside `ConsoleTool`.