### PR TITLE
fix GHA CI by using old macos for old python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,21 @@ jobs:
             python-version: "pypy3.10"
           - os: "windows-latest"
             python-version: "pypy3.10"
+          # Workaround for https://github.com/actions/setup-python/issues/696
+          - os: "macos-latest"
+            python-version: 3.7
+          - os: "macos-latest"
+            python-version: 3.8
+          - os: "macos-latest"
+            python-version: 3.9
+        include:
+          # Workaround for https://github.com/actions/setup-python/issues/696
+          - os: "macos-12"
+            python-version: 3.7
+          - os: "macos-12"
+            python-version: 3.8
+          - os: "macos-12"
+            python-version: 3.9
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,11 +96,11 @@ jobs:
             python-version: 3.9
         include:
           # Workaround for https://github.com/actions/setup-python/issues/696
-          - os: "macos-12"
+          - os: "macos-13"
             python-version: 3.7
-          - os: "macos-12"
+          - os: "macos-13"
             python-version: 3.8
-          - os: "macos-12"
+          - os: "macos-13"
             python-version: 3.9
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Workaround for https://github.com/actions/setup-python/issues/696