### PR TITLE
Escape invalid unicode in logging, log more locale info

### DIFF
--- a/b2/_internal/_cli/const.py
+++ b/b2/_internal/_cli/const.py
@@ -26,3 +26,6 @@ DEFAULT_THREADS = 10
 CREATE_BUCKET_TYPES = ('allPublic', 'allPrivate')
 
 B2_ESCAPE_CONTROL_CHARACTERS = 'B2_ESCAPE_CONTROL_CHARACTERS'
+
+# Set to 1 when running under B2 CLI as a Docker container
+B2_CLI_DOCKER_ENV_VAR = 'B2_CLI_DOCKER'

--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -5375,12 +5375,13 @@ class ConsoleTool:
     def _setup_logging(cls, args, argv):
         if args.log_config and (args.verbose or args.debug_logs):
             raise ValueError('Please provide either --log-config or --verbose/--debug-logs')
+        errors_kwarg = {'errors': 'backslashreplace'} if sys.version_info >= (3, 9) else {}
         if args.log_config:
             logging.config.fileConfig(args.log_config)
         elif args.verbose or args.debug_logs:
             # set log level to DEBUG for ALL loggers (even those not belonging to B2), but without any handlers,
             # those will added as needed (file and/or stderr)
-            logging.basicConfig(level=logging.DEBUG, handlers=[])
+            logging.basicConfig(level=logging.DEBUG, handlers=[], **errors_kwarg)
         else:
             logger.setLevel(logging.CRITICAL + 1)  # No logs!
         if args.verbose:
@@ -5395,7 +5396,7 @@ class ConsoleTool:
                 '%(asctime)s\t%(process)d\t%(thread)d\t%(name)s\t%(levelname)s\t%(message)s'
             )
             formatter.converter = time.gmtime
-            handler = logging.FileHandler('b2_cli.log')
+            handler = logging.FileHandler('b2_cli.log', **errors_kwarg)
             handler.setFormatter(formatter)
 
             # logs from ALL loggers sent to the log file should be formatted this way

--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -147,6 +147,7 @@ from b2._internal._cli.b2args import (
 from b2._internal._cli.const import (
     B2_APPLICATION_KEY_ENV_VAR,
     B2_APPLICATION_KEY_ID_ENV_VAR,
+    B2_CLI_DOCKER_ENV_VAR,
     B2_DESTINATION_SSE_C_KEY_B64_ENV_VAR,
     B2_DESTINATION_SSE_C_KEY_ID_ENV_VAR,
     B2_ENVIRONMENT_ENV_VAR,
@@ -5406,6 +5407,8 @@ class ConsoleTool:
 
         logger.info(r'// %s %s %s \\', SEPARATOR, VERSION.center(8), SEPARATOR)
         logger.debug('platform is %s', platform.platform())
+        if os.environ.get(B2_CLI_DOCKER_ENV_VAR) == "1":
+            logger.debug('running as a Docker container')
         logger.debug(
             'Python version is %s %s', platform.python_implementation(),
             sys.version.replace('\n', ' ')
@@ -5413,6 +5416,8 @@ class ConsoleTool:
         logger.debug('b2sdk version is %s', b2sdk_version)
         logger.debug('locale is %s', locale.getlocale())
         logger.debug('filesystem encoding is %s', sys.getfilesystemencoding())
+        logger.debug('default encoding is %s', sys.getdefaultencoding())
+        logger.debug('flags.utf8_mode is %s', sys.flags.utf8_mode)
 
 
 # used by Sphinx

--- a/changelog.d/+logging-encoding.fixed.md
+++ b/changelog.d/+logging-encoding.fixed.md
@@ -1,0 +1,1 @@
+Escape invalid unicode characters in log messages.

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -23,6 +23,7 @@ LABEL vcs-url="${vcs_url}"
 LABEL vcs-ref="${vcs_ref}"
 LABEL build-date-iso8601="${build_date}"
 
+ENV B2_CLI_DOCKER=1
 ENV PYTHONPATH=/opt/b2
 COPY ./docker/entrypoint.sh /entrypoint.sh
 COPY --from=builder /b2/__pypackages__/${python_version}/lib /opt/b2


### PR DESCRIPTION
Enable `backslashreplace` escaping in logging. Especially needed if for some reason Python decides to use `ascii` encoding as the default one.

Set `B2_CLI_DOCKER=1` env when running in Docker, and log a debug message if it's set.