### PR TITLE
Avoid failing on BrokenPipeError when running commands

### DIFF
--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -5475,6 +5475,10 @@ class ConsoleTool:
             logger.exception('ConsoleTool command interrupt')
             self._print_stderr('\nInterrupted.  Shutting down...\n')
             return 1
+        except BrokenPipeError:
+            # The command output has been likely piped in a shell
+            logger.debug('ConsoleTool broken pipe error', exc_info=True)
+            return 0
         except Exception:
             logger.exception('ConsoleTool unexpected exception')
             raise

--- a/changelog.d/1071.fixed.md
+++ b/changelog.d/1071.fixed.md
@@ -1,0 +1,1 @@
+Avoid failing on BrokenPipeError when running commands.


### PR DESCRIPTION
BrokenPipeError happens when a cli output has been piped to another program, which likely closes the pipe early because it already received enough data for it's use case (e.g. `head`)