### PR TITLE
Update Windows code signing to use KeyLocker

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -99,7 +99,7 @@ jobs:
       SM_API_KEY: ${{ secrets.SM_API_KEY }}
       SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
       SM_CLIENT_CERT_PASSWORD: ${{ secrets. SM_CLIENT_CERT_PASSWORD }}
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -124,7 +124,7 @@ jobs:
           echo "${{ env.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
           echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
         shell: bash
-      - name: Sign the bundle using a keypair alais
+      - name: Sign the bundle using a keypair alias
         id: sign
         run: nox -vs sign -- '${{ secrets.SM_KEYPAIR_ALIAS }}' '${{ secrets.SM_CERT_FINGERPRINT }}'
       - name: Generate hashes

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,8 +95,10 @@ jobs:
   deploy-windows-bundle:
     needs: deploy
     env:
-      B2_WINDOWS_CODE_SIGNING_CERTIFICATE: ${{ secrets.B2_WINDOWS_CODE_SIGNING_CERTIFICATE }}
-      B2_WINDOWS_CODE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.B2_WINDOWS_CODE_SIGNING_CERTIFICATE_PASSWORD }}
+      SM_HOST: ${{ secrets.SM_HOST }}
+      SM_API_KEY: ${{ secrets.SM_API_KEY }}
+      SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
+      SM_CLIENT_CERT_PASSWORD: ${{ secrets. SM_CLIENT_CERT_PASSWORD }}
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
@@ -112,18 +114,19 @@ jobs:
         id: bundle
         shell: bash
         run: nox -vs bundle
-      - name: Import certificate
-        id: windows_import_cert
-        if: ${{ env.B2_WINDOWS_CODE_SIGNING_CERTIFICATE != '' }}
-        uses: timheuer/base64-to-file@v1
-        with:
-          fileName: 'cert.pfx'
-          encodedString: ${{ secrets.B2_WINDOWS_CODE_SIGNING_CERTIFICATE }}
-      - name: Sign the bundle
-        if: ${{ env.B2_WINDOWS_CODE_SIGNING_CERTIFICATE != '' }}
-        id: sign
+      - name: Install client for code signing with Software Trust Manager
+        uses: digicert/ssm-code-signing@v1.1.0
+        env:
+          FORCE_DOWNLOAD_TOOLS: 'true'
+      - name: Set up client authentication certificate
+        id: client_cert
+        run: |
+          echo "${{ env.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
         shell: bash
-        run: nox -vs sign -- '${{ steps.windows_import_cert.outputs.filePath }}' '${{ env.B2_WINDOWS_CODE_SIGNING_CERTIFICATE_PASSWORD }}'
+      - name: Sign the bundle using a keypair alais
+        id: sign
+        run: nox -vs sign -- '${{ secrets.SM_KEYPAIR_ALIAS }}' '${{ secrets.SM_CERT_FINGERPRINT }}'
       - name: Generate hashes
         id: hashes
         run: nox -vs make_dist_digest

--- a/changelog.d/+keylocker_migration.changed.md
+++ b/changelog.d/+keylocker_migration.changed.md
@@ -1,1 +1,1 @@
-Switched to cloud-based signing using DigiCert KeyLocker
+Switched to cloud-based signing using DigiCert KeyLocker.

--- a/changelog.d/+keylocker_migration.changed.md
+++ b/changelog.d/+keylocker_migration.changed.md
@@ -1,0 +1,1 @@
+Switched to cloud-based signing using DigiCert KeyLocker


### PR DESCRIPTION
Update the GitHub actions in `cd.yml` to use DigiCert's [KeyLocker](https://docs.digicert.com/en/digicert-keylocker.html) and cloud based signing solutions for increased code signing certificate security.