### PR TITLE
Fix SystemError buffer overflow on Python 3.14+ and add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9", "pypy3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.9", "pypy3.10"]
         exclude:
           - os: "macos-latest"
             python-version: "pypy3.10"
@@ -118,7 +118,7 @@ jobs:
         run: nox -vs integration -p ${{ matrix.python-version }} -- -m "not require_secrets"
       - name: Run integration tests (with secrets)
         # Limit CI workload by running integration tests with secrets only on edge Python versions.
-        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' && contains(fromJSON('["3.8", "pypy3.10", "3.13"]'), matrix.python-version) }}
+        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' && contains(fromJSON('["3.8", "pypy3.10", "3.14"]'), matrix.python-version) }}
         run: nox -vs integration -p ${{ matrix.python-version }} -- -m "require_secrets" --cleanup
   test-docker:
     timeout-minutes: 90

--- a/b2/_internal/arg_parser.py
+++ b/b2/_internal/arg_parser.py
@@ -130,7 +130,14 @@ class B2ArgumentParser(argparse.ArgumentParser):
             return textwrap.dedent(value)
         else:
             encoding = self._get_encoding()
-            return rst2ansi(value.encode(encoding), output_encoding=encoding)
+            try:
+                return rst2ansi(value.encode(encoding), output_encoding=encoding)
+            except SystemError:
+                # FALLBACK(PARSER): rst2ansi can raise SystemError on Python 3.14+ due to
+                # buffer overflow bug in get_terminal_size ioctl call.
+                # See: https://github.com/Backblaze/B2_Command_Line_Tool/issues/1119
+                # TODO-REMOVE-BY: When rst2ansi is updated or replaced
+                return textwrap.dedent(value)
 
     def _make_short_description(self, usage: str, raw_description: str) -> str:
         if usage:

--- a/changelog.d/+python-3.14-support.infrastructure.md
+++ b/changelog.d/+python-3.14-support.infrastructure.md
@@ -1,0 +1,1 @@
+Added Python 3.14 support to CI/CD pipeline and test matrix.

--- a/changelog.d/1119.fixed.md
+++ b/changelog.d/1119.fixed.md
@@ -1,0 +1,1 @@
+Fixed SystemError buffer overflow crash on Python 3.14+ caused by rst2ansi's terminal size detection bug. The CLI now gracefully handles this error and continues to function normally.

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ PYTHON_VERSIONS = (
         '3.11',
         '3.12',
         '3.13',
+        '3.14',
     ]
     if NOX_PYTHONS is None
     else NOX_PYTHONS.split(',')
@@ -262,6 +263,42 @@ def run_integration_test(session, pytest_posargs):
 def integration(session):
     """Run integration tests."""
     run_integration_test(session, session.posargs)
+
+
+@nox.session(python=PYTHON_VERSIONS, name='integration_pty')
+def integration_pty(session):
+    """
+    Run PTY-dependent integration tests without pytest-xdist parallelization.
+
+    This session is specifically for tests that require real pseudo-terminal (PTY)
+    behavior, such as the buffer overflow test for Python 3.14+. Due to pytest-xdist
+    limitations, these tests must run serially to maintain proper PTY state.
+
+    Example usage:
+        nox -s integration_pty-3.14
+        nox -s integration_pty-3.11
+    """
+    pdm_install(session, 'license', 'test')
+
+    # Run the PTY test without -n flag to avoid pytest-xdist
+    command = [
+        'pytest',
+        'test/integration/test_help.py::test_help_with_tty',
+        '--log-level',
+        'INFO',
+        '-W',
+        'ignore::DeprecationWarning:rst2ansi.visitor:',
+        *PYTEST_GLOBAL_ARGS,
+        *session.posargs,
+    ]
+
+    # Get the executable path for the sut
+    versions = get_versions()
+    for cli_version in versions:
+        exe_path = session.run(
+            'python', '-c', f'import shutil; print(shutil.which("{cli_version}"))', silent=True
+        ).strip()
+        session.run(*command, '--sut', exe_path)
 
 
 @nox.session(python=PYTHON_VERSIONS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "argcomplete>=3.5.2,<4",

--- a/test/integration/test_help.py
+++ b/test/integration/test_help.py
@@ -7,9 +7,17 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+import os
 import platform
 import re
 import subprocess
+
+import pytest
+
+skip_on_windows = pytest.mark.skipif(
+    platform.system() == 'Windows',
+    reason='PTY tests require Unix-like system',
+)
 
 
 def test_help(cli_version):
@@ -26,3 +34,67 @@ def test_help(cli_version):
         expected_name += '.exe'
     assert re.match(r'^_?b2(v\d+)?(\.exe)?$', expected_name)  # test sanity check
     assert f'{expected_name} <command> --help' in p.stdout
+
+
+@skip_on_windows
+def test_help_with_tty(cli_version):
+    """
+    Test that B2 CLI works correctly with a real TTY (pseudo-terminal).
+
+    This test specifically verifies that the rst2ansi buffer overflow bug
+    on Python 3.14+ is properly handled. The bug occurs when rst2ansi's
+    get_terminal_size() function passes a 4-byte buffer to TIOCGWINSZ ioctl
+    which expects 8 bytes.
+
+    See: https://github.com/Backblaze/B2_Command_Line_Tool/issues/1119
+
+    NOTE: This test uses pexpect to create a real PTY. Due to pytest-xdist
+    limitations, this test may not correctly detect the buffer overflow when
+    run with parallelization (-n auto). For accurate testing on Python 3.14,
+    run without xdist:
+
+        pytest test/integration/test_help.py::test_help_with_tty -v
+
+    Or use the dedicated nox session:
+
+        nox -s integration_pty-3.14
+    """
+    pexpect = pytest.importorskip('pexpect')
+
+    # Set up environment - remove LINES/COLUMNS to ensure ioctl is called
+    env = os.environ.copy()
+    env.pop('LINES', None)
+    env.pop('COLUMNS', None)
+
+    # Spawn b2 --help with pexpect to create a real PTY
+    # This is where the bug would trigger on Python 3.14 without our fix
+    child = pexpect.spawn(
+        cli_version,
+        ['--help'],
+        env=env,
+        timeout=10,
+    )
+
+    # Wait for process to complete
+    child.expect(pexpect.EOF)
+
+    # Get the output
+    output = child.before.decode('utf-8', errors='replace')
+
+    # Check exit status
+    child.close()
+    exit_code = child.exitstatus
+
+    # Verify the command succeeded and produced help output
+    assert exit_code == 0, (
+        f'b2 --help failed with exit code {exit_code}.\n'
+        f'This may indicate the buffer overflow bug is not properly handled.\n'
+        f'Output: {output}\n'
+        f'See: https://github.com/Backblaze/B2_Command_Line_Tool/issues/1119'
+    )
+
+    # Verify help output contains expected content
+    assert 'b2 <command>' in output or cli_version in output, (
+        f'Help output does not contain expected content.\n'
+        f'Output: {output}'
+    )


### PR DESCRIPTION
This PR addresses issue #1119 where B2 CLI crashes with SystemError on Python 3.14+ due to a buffer overflow bug in the rst2ansi dependency.

Changes:
- Add try-except handler in arg_parser.py to catch SystemError from rst2ansi
- Fall back to plain text formatting when rst2ansi fails
- Add integration test to verify the fix works with real PTY on Python 3.14
- Add dedicated nox session (integration_pty) for PTY tests without xdist
- Add Python 3.14 to noxfile.py, CI matrix, and pyproject.toml

The root cause is in rst2ansi's get_terminal_size() which passes a 4-byte buffer to TIOCGWINSZ ioctl instead of the required 8 bytes. Python 3.14 enforces stricter buffer validation, triggering the error.

Fixes #1119