### PR TITLE
Disable _TqdmCloser darwin workaround for Python >= 3.14.2

### DIFF
--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -923,7 +923,12 @@ class _TqdmCloser:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if sys.platform != 'darwin' or os.environ.get('B2_TEST_DISABLE_TQDM_CLOSER'):
+        if (
+            sys.platform != 'darwin'
+            or sys.version_info < (3, 11)
+            or sys.version_info > (3, 14, 1)
+            or os.environ.get('B2_TEST_DISABLE_TQDM_CLOSER')
+        ):
             return
         try:
             from multiprocessing.synchronize import SemLock

--- a/changelog.d/+tqdm-closer-python314.fixed.md
+++ b/changelog.d/+tqdm-closer-python314.fixed.md
@@ -1,0 +1,1 @@
+Disable Tqdm semaphore leak workaround for Python >=3.14.2, as apparently it is no longer an issue in newer versions.

--- a/test/integration/test_tqdm_closer.py
+++ b/test/integration/test_tqdm_closer.py
@@ -14,8 +14,8 @@ import pytest
 
 
 @pytest.mark.skipif(
-    (sys.platform != 'darwin') or ((sys.version_info.major, sys.version_info.minor) < (3, 11)),
-    reason='Tqdm closing error only occurs on OSX and python 3.11 or newer',
+    (sys.platform != 'darwin') or (sys.version_info < (3, 11)) or (sys.version_info > (3, 14, 1)),
+    reason='Tqdm closing error only occurs on OSX and python >=3.11 up to 3.14.2',
 )
 def test_tqdm_closer(b2_tool, bucket, file_name):
     # test that stderr doesn't contain any warning, in particular warnings about multiprocessing resource tracker


### PR DESCRIPTION
_TqdmCloser is a workaround for leaked semaphores error happening when
using tqdm on MacOS and Python >= 3.11. The issue does not seem to
appear in Python 3.14.2, so we disable the workaround for newer Python
versions
