### PR TITLE
Disable _TqdmCloser darwin workaround for Python >= 3.14.2

### DIFF
--- a/changelog.d/+tqdm-closer-new-macos.fixed.md
+++ b/changelog.d/+tqdm-closer-new-macos.fixed.md
@@ -1,0 +1,1 @@
+Disable Tqdm semaphore leak workaround for MacOS >= 15.7.2, as apparently it is no longer an issue in newer versions.

--- a/test/integration/test_tqdm_closer.py
+++ b/test/integration/test_tqdm_closer.py
@@ -7,15 +7,14 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
-import re
 import sys
 
 import pytest
 
 
 @pytest.mark.skipif(
-    (sys.platform != 'darwin') or ((sys.version_info.major, sys.version_info.minor) < (3, 11)),
-    reason='Tqdm closing error only occurs on OSX and python 3.11 or newer',
+    (sys.platform != 'darwin'),
+    reason='Tqdm closing error only occurs on OSX',
 )
 def test_tqdm_closer(b2_tool, bucket, file_name):
     # test that stderr doesn't contain any warning, in particular warnings about multiprocessing resource tracker
@@ -26,19 +25,4 @@ def test_tqdm_closer(b2_tool, bucket, file_name):
             'cat',
             f'b2://{bucket.name}/{file_name}',
         ]
-    )
-
-    # test that disabling _TqdmCloser does produce a resource tracker warning. Should the following check ever fail,
-    # that would mean that either Tqdm or python fixed the issue and _TqdmCloser can be disabled for fixed versions
-    b2_tool.should_succeed(
-        [
-            'file',
-            'cat',
-            f'b2://{bucket.name}/{file_name}',
-        ],
-        additional_env={'B2_TEST_DISABLE_TQDM_CLOSER': '1'},
-        expected_stderr_pattern=re.compile(
-            r'UserWarning: resource_tracker: There appear to be \d+ leaked semaphore'
-            r' objects to clean up at shutdown'
-        ),
     )


### PR DESCRIPTION
_TqdmCloser is a workaround for leaked semaphores error happening when
using tqdm on MacOS and Python >= 3.11. The issue does not seem to
appear in Python 3.14.2, so we disable the workaround for newer Python
versions
