### PR TITLE
Avoid eager help message evaluation during parser construction

### DIFF
--- a/changelog.d/+arg_parse_help_eager.fixed.md
+++ b/changelog.d/+arg_parse_help_eager.fixed.md
@@ -1,0 +1,1 @@
+Avoid eager calculation of command help during parser construction.


### PR DESCRIPTION
Parser usage help messages are being extracted from text descriptions and processed via `rst2ansi`. The last step is quite expensive to compute.
The current PR fixes the eager processing of such help messages during parser initialization by making the computation lazy