### PR TITLE
Fix: allow dots in bucket name

### DIFF
--- a/b2/_internal/_utils/uri.py
+++ b/b2/_internal/_utils/uri.py
@@ -24,7 +24,7 @@ from b2sdk.v3 import (
 from b2sdk.v3.exception import B2Error
 
 _B2ID_PATTERN = re.compile(r'^b2id://(?P<file_id>[a-zA-Z0-9:_-]+)$', re.IGNORECASE)
-_B2_PATTERN = re.compile(r'^b2://(?P<bucket>[a-z0-9-]*)(?P<path>/.*)?$', re.IGNORECASE)
+_B2_PATTERN = re.compile(r'^b2://(?P<bucket>[a-z0-9.-]*)(?P<path>/.*)?$', re.IGNORECASE)
 _SCHEME_PATTERN = re.compile(r'(?P<scheme>[a-z0-9]*)://.*', re.IGNORECASE)
 _CONTROL_CHARACTERS_AND_SPACE = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f '
 

--- a/changelog.d/+b2-uri-bucket-period.fixed.md
+++ b/changelog.d/+b2-uri-bucket-period.fixed.md
@@ -1,0 +1,1 @@
+Fix `b2://` URI parsing to accept bucket names containing periods.

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -305,6 +305,23 @@ def test_download(b2_tool, persistent_bucket, sample_filepath, uploaded_sample_f
     assert output_b.read_text() == sample_filepath.read_text()
 
 
+def test_download__period_in_bucket_name(b2_tool, schedule_bucket_cleanup, sample_filepath, tmp_path):
+    bucket_name = b2_tool.generate_bucket_name()
+    bucket_name = bucket_name[:-2] + ".x"
+    schedule_bucket_cleanup(bucket_name)
+    b2_tool.should_succeed(
+        ['bucket', 'create', bucket_name, 'allPrivate', *b2_tool.get_bucket_info_args()]
+    )
+    b2_tool.should_succeed_json(
+        ['file', 'upload', '--quiet', bucket_name, str(sample_filepath), 'kitten.jpg']
+    )
+    output = tmp_path / 'kitten.jpg'
+    b2_tool.should_succeed(
+        ['file', 'download', '--quiet', f'b2://{bucket_name}/kitten.jpg', str(output)]
+    )
+    assert output.read_text() == sample_filepath.read_text()
+
+
 def test_basic(b2_tool, persistent_bucket, sample_file, tmp_path, b2_uri_args, apiver_int):
     bucket_name = persistent_bucket.bucket_name
     subfolder = f'{persistent_bucket.subfolder}/'

--- a/test/unit/_utils/test_uri.py
+++ b/test/unit/_utils/test_uri.py
@@ -63,6 +63,8 @@ def test_b2fileuri_str():
         ('./some/local/path', Path('some/local/path')),
         ('.', Path('')),
         ('b2://bucket', B2URI(bucket_name='bucket')),
+        ('b2://one.two/kitten.jpg', B2URI(bucket_name='one.two', path='kitten.jpg')),
+        ('b2://one.two', B2URI(bucket_name='one.two')),
         (' b2://bucket', B2URI(bucket_name='bucket')),
         ('b2://bucket/', B2URI(bucket_name='bucket')),
         ('b2://bucket/path/to/dir/', B2URI(bucket_name='bucket', path='path/to/dir/')),


### PR DESCRIPTION
According to [official documentation](https://www.backblaze.com/docs/cloud-storage-buckets) bucket names should allow dots (`.`). This PR adds dot to a list of allowed characters.

It's also important to mention that the current CLI implementation only restricts bucket name characters to [a-z0-9.-], while the actual rules are more restrictive (for example, bucket names cannot start or end with a dot or contain consecutive dots). However, we don't enforce any additional naming rules at the CLI level and instead allow the B2 API to perform the validation and return an error. This way, the bucket name rules are always up-to-date, and we don't need to update the CLI if the rules change on the API side.